### PR TITLE
fix: update slash commands to match current codebase

### DIFF
--- a/.claude/commands/accept-pr.md
+++ b/.claude/commands/accept-pr.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(gh pr view*), Bash(gh pr diff*), Bash(gh pr review*), Bash(gh pr merge*), Bash(git pull*), Bash(git log*)
+allowed-tools: Bash(gh pr view*), Bash(gh pr diff*), Bash(gh pr review*), Bash(gh pr merge*), Bash(git pull*), Bash(git log*), Bash(git checkout*)
 ---
 
 Approve and merge a PR. Usage: `/accept-pr <me|claude> <pr-number>`
@@ -11,13 +11,14 @@ Parse `$ARGUMENTS` to extract the signer and PR number. The first word is the si
 1. Parse `$ARGUMENTS` — expect two values: `<signer>` and `<pr-number>`
    - If missing or invalid, show usage and stop
    - Valid signers: `me` (user's git identity) or `claude` (Claude as author)
-2. Run `gh pr view <pr-number>` to verify the PR exists and is open
+2. Run `gh pr view <pr-number> --json title,state,body,baseRefName,headRefName,commits,files` to verify the PR exists and is open
 3. Run `gh pr diff <pr-number>` to review the changes
 4. Provide a brief summary of what the PR does
 5. Ask the user to confirm the merge
-6. Approve the PR: `gh pr review <pr-number> --approve --body "LGTM"`
+6. Try to approve the PR: `gh pr review <pr-number> --approve --body "LGTM"`
+   - If self-approve fails (own PR), skip approval and proceed to merge
 7. Merge the PR based on signer:
    - **me**: `gh pr merge <pr-number> --squash --delete-branch`
    - **claude**: `gh pr merge <pr-number> --squash --delete-branch --author-email "noreply@anthropic.com"`
-8. Run `git pull` to sync local main
+8. Run `git checkout main && git pull` to sync local main
 9. Show the merge result

--- a/.claude/commands/check.md
+++ b/.claude/commands/check.md
@@ -1,10 +1,12 @@
 Run the full pre-commit checklist for this project. Execute each step sequentially and report results:
 
-1. `make lint` — Code quality (golangci-lint)
-2. `make critic` — Code review (go-critic)
-3. `make sec` — Security scan (gosec)
-4. `make test` — Unit tests
-5. `make api-docs` — Regenerate Swagger docs
-6. `make build` — Compile binary
+1. `make lint` — Code quality (golangci-lint, 60+ linters)
+2. `make sec` — Security scan (gosec)
+3. `make vulncheck` — Dependency vulnerability check (govulncheck)
+4. `make secrets` — Secrets detection (gitleaks)
+5. `make lint-ci` — GitHub Actions lint (actionlint)
+6. `make test` — Unit tests
+7. `make api-docs` — Regenerate Swagger docs
+8. `make build` — Compile binary
 
 After all steps, provide a summary table showing pass/fail status for each check. If any step fails, show the relevant error output and suggest a fix.

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -4,8 +4,10 @@ Guide me through creating a new release for this project:
 2. Ask what the new version should be (suggest next patch, minor, and major versions)
 3. Run the full pre-commit checklist:
    - `make lint`
-   - `make critic`
    - `make sec`
+   - `make vulncheck`
+   - `make secrets`
+   - `make lint-ci`
    - `make test`
    - `make api-docs`
    - `make build`

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -6,7 +6,7 @@ Review PR #$ARGUMENTS for quality, security, and correctness.
 
 ## Steps
 
-1. Run `gh pr view $ARGUMENTS` to get PR title, description, base branch, and status
+1. Run `gh pr view $ARGUMENTS --json title,state,body,baseRefName,headRefName,commits,files` to get PR title, description, base branch, and status
 2. Run `gh pr diff $ARGUMENTS` to get the full diff
 3. For each changed file, analyze the diff and check for:
    - **Bugs**: Logic errors, nil pointer risks, off-by-one errors, race conditions


### PR DESCRIPTION
## Summary
- Replace nonexistent `make critic` with `make vulncheck`, `make secrets`, and `make lint-ci` in `/check` and `/release` commands
- Use `gh pr view --json` in `/review-pr` and `/accept-pr` to avoid GitHub Projects Classic deprecation error
- Handle self-approve failure gracefully in `/accept-pr` (skip approval for own PRs)
- Add `git checkout main` before `git pull` in `/accept-pr` to ensure correct branch sync

## Test plan
- [ ] Verify `/check` runs all 8 steps matching `make static-check` target
- [ ] Verify `/release` pre-commit checklist includes vulncheck, secrets, lint-ci
- [ ] Verify `/review-pr <number>` fetches PR details without error
- [ ] Verify `/accept-pr me <number>` handles self-approve gracefully