### PR TITLE
docs: use dynamic Go version in README install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ See [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md) for C4 diagrams (Context, Con
 
 - [gvm](https://github.com/moovweb/gvm) Go
     ```bash
-    gvm install go1.26.0 --prefer-binary --with-build-tools --with-protobuf
-    gvm use go1.26.0 --default
+    LATEST_GO=$(curl -s 'https://go.dev/VERSION?m=text' | head -1)
+    gvm install "$LATEST_GO" --prefer-binary --with-build-tools --with-protobuf
+    gvm use "$LATEST_GO" --default
     ```
   - [nmv](https://github.com/nvm-sh/nvm) Node
   ```bash


### PR DESCRIPTION
## Summary
- Replace hardcoded `go1.26.0` with dynamic version fetched from `https://go.dev/VERSION?m=text`
- README install instructions now always point to the latest stable Go release

## Test plan
- [ ] Verify `curl -s 'https://go.dev/VERSION?m=text' | head -1` returns a valid Go version (e.g., `go1.26.0`)
- [ ] Verify the gvm commands work with the fetched version