### PR TITLE
ci: fix duplicate workflow runs and gate Docker by tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ run-name: ci
 on:
   push:
     branches: [main]
+    tags: ['v*']
   pull_request:
   workflow_call:
 


### PR DESCRIPTION
## Summary
- Restrict push trigger to default branch + tags
- Remove branch filter from pull_request
- Add concurrency group to cancel superseded runs

## Test plan
- [ ] Verify PRs trigger CI once (not twice)
- [ ] Verify Docker push only happens on tag push