### PR TITLE
chore: migrate quality toolchain to mise and align CI + docs

### DIFF
--- a/.claude/skills/environment/SKILL.md
+++ b/.claude/skills/environment/SKILL.md
@@ -65,7 +65,7 @@ Most build targets depend on `deps` and auto-install missing tools.
 | `image-push` | image-build | Push Docker image to GHCR |
 | `image-smoke-test` | — | Smoke-test a pre-built container |
 | `image-test` | image-build, image-smoke-test | Build + smoke test container |
-| `image-scan` | deps-trivy, build | Build image + Trivy scan |
+| `image-scan` | deps, build | Build image + Trivy scan (trivy installed via mise) |
 | `build-image` | deps, api-docs, lint, sec, vulncheck, secrets | Multi-platform build + push |
 | `release` | lint, sec, vulncheck, test, api-docs, build | Tag and push release |
 | `e2e` | deps | Newman E2E tests |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,29 +52,25 @@ jobs:
         with:
           fetch-depth: 0  # needed for gitleaks / git history scans
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      # Single source of truth for Go + every quality/security tool is
+      # .mise.toml — mise-action reads it, installs everything, and caches the
+      # mise-managed installs. Replaces actions/setup-go and the parallel
+      # `~/.local/bin` + `~/go/bin` caches that were needed when tools were
+      # installed piecemeal by the Makefile.
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          go-version-file: 'go.mod'
+          install: true
           cache: true
 
-      - name: Cache Go tool binaries
+      - name: Cache Go module + build cache
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
-          path: ~/go/bin
-          key: go-tools-${{ runner.os }}-${{ hashFiles('Makefile') }}
-
-      # Off-canonical: Makefile installs hadolint/shellcheck/trivy/act/goreleaser
-      # to ~/.local/bin; caching avoids re-downloading on every run.
-      - name: Cache local bin tools
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        with:
-          path: ~/.local/bin
-          key: local-bin-${{ runner.os }}-${{ hashFiles('Makefile') }}
-
-      - name: Add Go bin to PATH
-        run: |
-          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-mod-${{ runner.os }}-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            go-mod-${{ runner.os }}-
 
       - name: Static check
         run: make static-check
@@ -86,19 +82,20 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          go-version-file: 'go.mod'
+          install: true
           cache: true
 
-      - name: Cache Go tool binaries
+      - name: Cache Go module + build cache
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
-          path: ~/go/bin
-          key: go-tools-${{ runner.os }}-${{ hashFiles('Makefile') }}
-
-      - name: Add Go bin to PATH
-        run: echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-mod-${{ runner.os }}-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            go-mod-${{ runner.os }}-
 
       - name: Build
         run: make build
@@ -118,16 +115,20 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          go-version-file: 'go.mod'
+          install: true
           cache: true
 
-      - name: Cache Go tool binaries
+      - name: Cache Go module + build cache
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
-          path: ~/go/bin
-          key: go-tools-${{ runner.os }}-${{ hashFiles('Makefile') }}
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-mod-${{ runner.os }}-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            go-mod-${{ runner.os }}-
 
       - name: Test with coverage
         run: make coverage-check
@@ -150,10 +151,20 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          go-version-file: 'go.mod'
+          install: true
           cache: true
+
+      - name: Cache Go module + build cache
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-mod-${{ runner.os }}-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            go-mod-${{ runner.os }}-
 
       - name: Integration test
         run: make integration-test
@@ -172,14 +183,23 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      # mise-action installs BOTH go (from .mise.toml) and node (from
+      # .mise.toml, which mirrors .nvmrc). Replaces the parallel setup-go +
+      # setup-node pair.
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          go-version-file: 'go.mod'
+          install: true
           cache: true
 
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+      - name: Cache Go module + build cache
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
-          node-version: lts/*
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-mod-${{ runner.os }}-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            go-mod-${{ runner.os }}-
 
       - name: Cache Newman
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
@@ -225,11 +245,13 @@ jobs:
         with:
           name: server-binary
 
-      # Fallback path: install Go and rebuild if artifact download failed
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      # Fallback path: install toolchain via mise and rebuild if artifact
+      # download failed (pulls Go from .mise.toml — same source of truth as
+      # the build job).
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         if: steps.download-binary.outcome == 'failure'
         with:
-          go-version-file: 'go.mod'
+          install: true
           cache: true
 
       - name: Build
@@ -289,16 +311,16 @@ jobs:
         with:
           fetch-depth: 0   # goreleaser needs full history for changelog
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          go-version-file: 'go.mod'
+          install: true
           cache: true
 
+      # goreleaser is already installed by mise-action (pinned in .mise.toml),
+      # so invoke the binary directly — avoids goreleaser-action's parallel
+      # installer and the second version pin that used to live in this step.
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
-        with:
-          version: 'v2.15.2' # renovate: depName=goreleaser/goreleaser datasource=github-releases
-          args: release --clean -f ./.goreleaser.yml
+        run: goreleaser release --clean -f ./.goreleaser.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/claude-ci-fix.yml
+++ b/.github/workflows/claude-ci-fix.yml
@@ -127,10 +127,10 @@ jobs:
           ref: ${{ steps.guard.outputs.head_branch }}
           fetch-depth: 1
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         if: steps.guard.outputs.skip != 'true'
         with:
-          go-version-file: 'go.mod'
+          install: true
           cache: true
 
       - name: Set up Claude config

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,3 +1,28 @@
 [tools]
+# Language toolchains (Go version mirrors go.mod; node mirrors .nvmrc)
 go = "1.26.2"
 node = "24"
+
+# Static analysis + security tooling — version-of-truth for local + CI.
+# Each pin is Renovate-tracked via the inline comment (see renovate.json
+# `.mise.toml` customManager).
+# renovate: datasource=github-releases depName=golangci/golangci-lint
+golangci-lint = "2.11.4"
+# renovate: datasource=github-releases depName=securego/gosec
+"aqua:securego/gosec" = "2.25.0"
+# renovate: datasource=go depName=golang.org/x/vuln/cmd/govulncheck
+"go:golang.org/x/vuln/cmd/govulncheck" = "1.1.4"
+# renovate: datasource=github-releases depName=zricethezav/gitleaks
+gitleaks = "8.30.1"
+# renovate: datasource=github-releases depName=rhysd/actionlint
+actionlint = "1.7.12"
+# renovate: datasource=github-releases depName=koalaman/shellcheck
+shellcheck = "0.11.0"
+# renovate: datasource=github-releases depName=hadolint/hadolint
+hadolint = "2.14.0"
+# renovate: datasource=github-releases depName=aquasecurity/trivy
+trivy = "0.69.3"
+# renovate: datasource=github-releases depName=nektos/act
+act = "0.2.87"
+# renovate: datasource=github-releases depName=goreleaser/goreleaser
+goreleaser = "2.15.2"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,13 +100,8 @@ func FlightRoutes(e *echo.Echo, h *handlers.Handler) {
 
 ```bash
 make help           # List available tasks
-make deps           # Install tools (swag, golangci-lint, gosec, govulncheck, gitleaks, actionlint, benchstat, newman) via mise + corepack; node is read from .mise.toml (pre-install via `mise install`)
+make deps           # Install toolchain — `mise install` reads .mise.toml and provisions Go, Node, and every quality/security tool (golangci-lint, gosec, govulncheck, gitleaks, actionlint, shellcheck, hadolint, trivy, act, goreleaser). swag + benchstat stay Go-installed; newman via pnpm + corepack
 make deps-check     # Show required Go version, mise status, and tool status
-make deps-hadolint  # Install hadolint for Dockerfile linting (to $HOME/.local/bin)
-make deps-shellcheck # Install shellcheck for shell script linting (to $HOME/.local/bin)
-make deps-act       # Install act for running GitHub Actions locally (to $HOME/.local/bin)
-make deps-trivy     # Install trivy for local vulnerability scanning (to $HOME/.local/bin)
-make deps-goreleaser # Install goreleaser for .goreleaser.yml validation (to $HOME/.local/bin)
 make api-docs       # Generate Swagger docs (run after changing Swagger comments)
 make format         # Format Go code
 make lint           # Run golangci-lint + hadolint (comprehensive linting via .golangci.yml)
@@ -158,22 +153,18 @@ make deps-prune-check # Verify no prunable dependencies (CI gate)
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `APP_NAME` | flight-path | Application name (used in Docker tags) |
-| `GO_VERSION` | (auto-extracted from go.mod) | Go version auto-parsed from `go.mod` via regex |
-| `SWAG_VERSION` | 2.0.0-rc5 | Swagger code generator |
-| `GOSEC_VERSION` | 2.25.0 | Go security scanner |
-| `GOLANGCI_VERSION` | 2.11.4 | Go meta-linter |
-| `GOVULNCHECK_VERSION` | 1.1.4 | Go vulnerability checker |
-| `GITLEAKS_VERSION` | 8.30.1 | Secrets scanner |
-| `ACTIONLINT_VERSION` | 1.7.12 | GitHub Actions linter |
-| `BENCHSTAT_VERSION` | 0.0.0-20260409210113-8e83ce0f7b1c | Benchmark comparison |
-| `HADOLINT_VERSION` | 2.14.0 | Dockerfile linter |
-| `TRIVY_VERSION` | 0.69.3 | Vulnerability scanner |
-| `ACT_VERSION` | 0.2.87 | Local GitHub Actions runner |
-| `GORELEASER_VERSION` | 2.15.2 | GoReleaser (config validator via `goreleaser check` in every push) |
-| `SHELLCHECK_VERSION` | 0.11.0 | Shell script linter (used by actionlint) |
+| `GO_VERSION` | (auto-extracted from go.mod) | Go version auto-parsed from `go.mod` via regex (mise also reads `go.mod` natively) |
+| `SWAG_VERSION` | 2.0.0-rc5 | Swagger code generator (Go install — no stable mise backend) |
+| `BENCHSTAT_VERSION` | 0.0.0-20260409210113-8e83ce0f7b1c | Benchmark comparison (Go install) |
 | `MERMAID_CLI_VERSION` | 11.12.0 | Mermaid diagram validator (Docker image) |
-| `MISE_VERSION` | 2026.4.11 | Toolchain version manager (reads `.mise.toml` — pins Go + Node) |
+| `MISE_VERSION` | 2026.4.11 | Toolchain version manager bootstrap (reads `.mise.toml`) |
 | `NODE_VERSION` | 24 | Node.js major version (source of truth: `.nvmrc` / `.mise.toml`; installed via mise) |
+
+The quality/security toolchain (golangci-lint, gosec, govulncheck, gitleaks,
+actionlint, shellcheck, hadolint, trivy, act, goreleaser) is pinned in
+`.mise.toml` — one source of truth, consumed by both local dev (`make deps` →
+`mise install --yes`) and CI (`jdx/mise-action`). Do not re-pin these tools in
+the Makefile or workflow YAML.
 
 ## Before Committing
 
@@ -232,21 +223,25 @@ Update specs when changing architecture, API, or testing strategy.
 
 ## Dev Tools
 
-| Tool | Purpose | Install |
+All quality/security tools below are installed in one pass by
+`mise install --yes` (run by `make deps`). Versions are pinned in `.mise.toml`.
+
+| Tool | Purpose | Source |
 |---|---|---|
-| `golangci-lint` | Meta-linter (configured via `.golangci.yml`) | `make deps` |
-| `gosec` | Security scanner | `make deps` |
-| `govulncheck` | Dependency vulnerability check | `make deps` |
-| `gitleaks` | Secrets detection | `make deps` |
-| `actionlint` | GitHub Actions linter | `make deps` |
-| `benchstat` | Benchmark comparison | `make deps` |
-| `swag` | Swagger generation | `make deps` |
-| `newman` | E2E API testing | `make deps` |
-| `hadolint` | Dockerfile linter | `make lint` (auto-installed via `deps-hadolint`) |
-| `shellcheck` | Shell script linter (used by actionlint inside `run:` steps) | `make lint-ci` (auto-installed via `deps-shellcheck`) |
+| `golangci-lint` | Meta-linter (configured via `.golangci.yml`) | mise / `.mise.toml` |
+| `gosec` | Security scanner | mise / `.mise.toml` (aqua:securego/gosec) |
+| `govulncheck` | Dependency vulnerability check | mise / `.mise.toml` (go: backend) |
+| `gitleaks` | Secrets detection | mise / `.mise.toml` |
+| `actionlint` | GitHub Actions linter | mise / `.mise.toml` |
+| `shellcheck` | Shell script linter (used by actionlint inside `run:` steps) | mise / `.mise.toml` |
+| `hadolint` | Dockerfile linter | mise / `.mise.toml` |
+| `trivy` | Vulnerability scanner (images + filesystem) | mise / `.mise.toml` |
+| `act` | Local GitHub Actions runner | mise / `.mise.toml` |
+| `goreleaser` | Release binary builder + `.goreleaser.yml` validator | mise / `.mise.toml` |
+| `swag` | Swagger generation | `go install` (pinned via `SWAG_VERSION` in Makefile) |
+| `benchstat` | Benchmark comparison | `go install` (pinned via `BENCHSTAT_VERSION` in Makefile) |
+| `newman` | E2E API testing | `pnpm install` in `test/` (pinned in `test/package.json`) |
 | `mermaid-cli` | Mermaid diagram validator (runs as Docker image) | `make mermaid-lint` (pulls image on demand) |
-| `trivy` | Vulnerability scanner (images + filesystem) | `make static-check` or `make deps-trivy` |
-| `act` | Local GitHub Actions runner | `make deps-act` |
 
 ## CI/CD
 
@@ -318,5 +313,5 @@ Items identified by upgrade analysis. Review periodically, act when conditions c
 
 - Go 1.26.2 via mise (reads `.mise.toml`); install with `curl -fsSL https://mise.jdx.dev/install.sh | bash`
 - Node.js via mise (reads `.mise.toml` / `.nvmrc`); pnpm enabled via corepack
-- User-writable tool install dir: `$HOME/.local/bin` (hadolint, shellcheck, act, trivy) — exported to `PATH` by the Makefile
+- Quality/security tools (golangci-lint, gosec, govulncheck, gitleaks, actionlint, shellcheck, hadolint, trivy, act, goreleaser) are mise-managed and surface on `PATH` via `$HOME/.local/share/mise/shims` (exported by the Makefile alongside `$HOME/.local/bin` for the mise installer itself)
 - Environment variables loaded from `.env` (`SERVER_PORT=8080`)

--- a/Makefile
+++ b/Makefile
@@ -19,48 +19,38 @@ COVPROF := $(HOMEDIR)/covprof.out
 # === Go Version (from go.mod — tracked by Renovate's gomod manager, not here) ===
 GO_VERSION := $(shell grep -oP '^go \K[0-9.]+' go.mod)
 
-# === Tool Versions (pinned) ===
+# === Tool Versions ===
+# The project's quality/security toolchain (golangci-lint, gosec, govulncheck,
+# gitleaks, actionlint, shellcheck, hadolint, trivy, act, goreleaser) is pinned
+# in .mise.toml — one source of truth, consumed by both local dev and CI
+# (jdx/mise-action). Do NOT re-pin those tools here.
+#
+# The remaining Makefile-level pins are for tools that mise does not manage:
+# Go-installed tools without a stable aqua backend, and Docker-image tools.
+
 # renovate: datasource=github-releases depName=swaggo/swag
 SWAG_VERSION        := 2.0.0-rc5
-# renovate: datasource=github-releases depName=securego/gosec
-GOSEC_VERSION       := 2.25.0
 # renovate: datasource=go depName=golang.org/x/perf/cmd/benchstat versioning=loose
 BENCHSTAT_VERSION   := 0.0.0-20260409210113-8e83ce0f7b1c
-# renovate: datasource=github-releases depName=golangci/golangci-lint
-GOLANGCI_VERSION    := 2.11.4
-# renovate: datasource=go depName=golang.org/x/vuln/cmd/govulncheck
-GOVULNCHECK_VERSION := 1.1.4
-# renovate: datasource=github-releases depName=zricethezav/gitleaks
-GITLEAKS_VERSION    := 8.30.1
-# renovate: datasource=github-releases depName=rhysd/actionlint
-ACTIONLINT_VERSION  := 1.7.12
-# renovate: datasource=github-releases depName=koalaman/shellcheck
-SHELLCHECK_VERSION  := 0.11.0
 # NODE_VERSION tracks major only — source of truth: .nvmrc (Renovate cannot track major-only values).
 # Node is installed via mise (.mise.toml pins `node = "24"`); .nvmrc is kept for mise's native read.
 NODE_VERSION        := $(shell cat .nvmrc 2>/dev/null || echo 24)
 # pnpm is pinned in test/package.json via the `packageManager` field (corepack auto-switches).
 # renovate: datasource=github-releases depName=jdx/mise
 MISE_VERSION        := 2026.4.11
-# renovate: datasource=github-releases depName=hadolint/hadolint
-HADOLINT_VERSION    := 2.14.0
-# renovate: datasource=github-releases depName=aquasecurity/trivy
-TRIVY_VERSION       := 0.69.3
-# renovate: datasource=github-releases depName=nektos/act
-ACT_VERSION         := 0.2.87
-# renovate: datasource=github-releases depName=goreleaser/goreleaser
-GORELEASER_VERSION  := 2.15.2
 # renovate: datasource=docker depName=minlag/mermaid-cli
 MERMAID_CLI_VERSION := 11.12.0
 
-# Ensure tools installed to ~/.local/bin (hadolint, act, shellcheck, etc.) are
-# on PATH for every recipe — needed inside the act runner container where this
-# path is not preconfigured. Exported so every sub-shell the recipes spawn inherits it.
-export PATH := $(HOME)/.local/bin:$(PATH)
+# Ensure tools installed to ~/.local/bin (mise bootstrap lives here) AND mise's
+# shim dir (hadolint, trivy, act, goreleaser, golangci-lint, gosec, gitleaks,
+# actionlint, shellcheck, govulncheck) are on PATH for every recipe — needed
+# inside the act runner container where neither path is preconfigured.
+# Exported so every sub-shell the recipes spawn inherits it.
+export PATH := $(HOME)/.local/bin:$(HOME)/.local/share/mise/shims:$(PATH)
 
 # === Go version management: mise (https://mise.jdx.dev) ===
 # mise auto-activates via shell hook, reads .mise.toml, and publishes semver releases
-# trackable by Renovate. CI uses actions/setup-go (reads go.mod directly).
+# trackable by Renovate. CI uses jdx/mise-action (reads .mise.toml directly).
 HAS_MISE := $(shell command -v mise >/dev/null 2>&1 && echo true || echo false)
 define go-exec
 $(if $(filter true,$(HAS_MISE)),bash -c 'eval "$$(mise activate bash --shims)" && $(1)',bash -c '$(1)')
@@ -74,28 +64,27 @@ help:
 
 #deps: @ Download and install dependencies
 deps:
-	@# Install mise if not present (local development only; CI uses actions/setup-go)
+	@# Install mise if not present (local development only; CI uses jdx/mise-action)
 	@if [ -z "$$CI" ] && ! command -v mise >/dev/null 2>&1; then \
 		echo "Installing mise v$(MISE_VERSION)..."; \
 		curl -fsSL https://mise.jdx.dev/install.sh | MISE_VERSION=v$(MISE_VERSION) bash; \
 		echo ""; \
 		echo "mise installed. Activate by adding to your shell rc:"; \
 		echo "  eval \"\$$(mise activate bash)\"  # or zsh/fish"; \
-		echo "Then re-run 'make deps' to install Go $(GO_VERSION) via mise."; \
+		echo "Then re-run 'make deps' to install the toolchain pinned in .mise.toml."; \
 		exit 0; \
 	fi
+	@# mise install reads .mise.toml and provisions go, node, and every quality/
+	@# security tool (golangci-lint, gosec, govulncheck, gitleaks, actionlint,
+	@# shellcheck, hadolint, trivy, act, goreleaser) in one pass. Idempotent.
 	@if [ "$(HAS_MISE)" = "true" ]; then \
 		mise install --yes; \
 	else \
 		command -v go >/dev/null 2>&1 || { echo "Error: Go required. Install mise from https://mise.jdx.dev or Go from https://go.dev/dl/"; exit 1; }; \
 	fi
+	@# Tools that don't have a stable mise backend stay Go-installed.
 	@$(call go-exec,command -v swag) >/dev/null 2>&1 || { echo "Installing swag..."; $(call go-exec,go install github.com/swaggo/swag/v2/cmd/swag@v$(SWAG_VERSION)); }
-	@$(call go-exec,command -v gosec) >/dev/null 2>&1 || { echo "Installing gosec..."; $(call go-exec,go install github.com/securego/gosec/v2/cmd/gosec@v$(GOSEC_VERSION)); }
 	@$(call go-exec,command -v benchstat) >/dev/null 2>&1 || { echo "Installing benchstat..."; $(call go-exec,go install golang.org/x/perf/cmd/benchstat@v$(BENCHSTAT_VERSION)); }
-	@$(call go-exec,command -v golangci-lint) >/dev/null 2>&1 || { echo "Installing golangci-lint..."; curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $$($(call go-exec,go env GOPATH))/bin v$(GOLANGCI_VERSION); }
-	@$(call go-exec,command -v govulncheck) >/dev/null 2>&1 || { echo "Installing govulncheck..."; $(call go-exec,go install golang.org/x/vuln/cmd/govulncheck@v$(GOVULNCHECK_VERSION)); }
-	@$(call go-exec,command -v gitleaks) >/dev/null 2>&1 || { echo "Installing gitleaks..."; $(call go-exec,go install github.com/zricethezav/gitleaks/v8@v$(GITLEAKS_VERSION)); }
-	@$(call go-exec,command -v actionlint) >/dev/null 2>&1 || { echo "Installing actionlint..."; $(call go-exec,go install github.com/rhysd/actionlint/cmd/actionlint@v$(ACTIONLINT_VERSION)); }
 	@command -v node >/dev/null 2>&1 || { \
 		echo "Error: Node.js not found. Install mise (https://mise.jdx.dev), then run 'mise install' — .mise.toml pins node=$(NODE_VERSION)."; \
 		exit 1; \
@@ -108,53 +97,10 @@ deps-check:
 	@echo "Go version required: $(GO_VERSION)"
 	@if command -v mise >/dev/null 2>&1; then mise list 2>/dev/null || echo "mise: .mise.toml not trusted — run 'mise trust'"; else echo "mise not installed - install from https://mise.jdx.dev"; fi
 	@echo "--- Tool status ---"
-	@for tool in swag gosec benchstat golangci-lint govulncheck gitleaks actionlint node pnpm hadolint act trivy goreleaser shellcheck; do \
+	@for tool in swag benchstat golangci-lint gosec govulncheck gitleaks actionlint shellcheck hadolint trivy act goreleaser node pnpm; do \
 		printf "  %-16s " "$$tool:"; \
 		command -v $$tool >/dev/null 2>&1 && echo "installed" || echo "NOT installed"; \
 	done
-
-#deps-hadolint: @ Install hadolint for Dockerfile linting
-deps-hadolint:
-	@command -v hadolint >/dev/null 2>&1 || { echo "Installing hadolint $(HADOLINT_VERSION)..."; \
-		mkdir -p $$HOME/.local/bin; \
-		curl -sSfL -o /tmp/hadolint https://github.com/hadolint/hadolint/releases/download/v$(HADOLINT_VERSION)/hadolint-Linux-x86_64 && \
-		install -m 755 /tmp/hadolint $$HOME/.local/bin/hadolint && \
-		rm -f /tmp/hadolint; \
-	}
-
-#deps-shellcheck: @ Install shellcheck for shell script linting
-deps-shellcheck:
-	@command -v shellcheck >/dev/null 2>&1 || { echo "Installing shellcheck $(SHELLCHECK_VERSION)..."; \
-		mkdir -p $$HOME/.local/bin; \
-		curl -sSfL -o /tmp/shellcheck.tar.xz https://github.com/koalaman/shellcheck/releases/download/v$(SHELLCHECK_VERSION)/shellcheck-v$(SHELLCHECK_VERSION).linux.x86_64.tar.xz && \
-		tar -xJf /tmp/shellcheck.tar.xz -C /tmp && \
-		install -m 755 /tmp/shellcheck-v$(SHELLCHECK_VERSION)/shellcheck $$HOME/.local/bin/shellcheck && \
-		rm -rf /tmp/shellcheck-v$(SHELLCHECK_VERSION) /tmp/shellcheck.tar.xz; \
-	}
-
-#deps-act: @ Install act for running GitHub Actions locally
-deps-act: deps
-	@command -v act >/dev/null 2>&1 || { echo "Installing act $(ACT_VERSION)..."; \
-		mkdir -p $$HOME/.local/bin; \
-		curl -sSfL https://raw.githubusercontent.com/nektos/act/master/install.sh | bash -s -- -b $$HOME/.local/bin v$(ACT_VERSION); \
-	}
-
-#deps-trivy: @ Install trivy for local vulnerability scanning
-deps-trivy:
-	@command -v trivy >/dev/null 2>&1 || { echo "Installing trivy $(TRIVY_VERSION)..."; \
-		mkdir -p $$HOME/.local/bin; \
-		curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b $$HOME/.local/bin v$(TRIVY_VERSION); \
-	}
-
-#deps-goreleaser: @ Install goreleaser for local release config validation
-deps-goreleaser:
-	@command -v goreleaser >/dev/null 2>&1 || { echo "Installing goreleaser $(GORELEASER_VERSION)..."; \
-		mkdir -p $$HOME/.local/bin; \
-		curl -sSfL "https://github.com/goreleaser/goreleaser/releases/download/v$(GORELEASER_VERSION)/goreleaser_Linux_x86_64.tar.gz" -o /tmp/goreleaser.tar.gz && \
-		tar -xzf /tmp/goreleaser.tar.gz -C /tmp goreleaser && \
-		install -m 755 /tmp/goreleaser $$HOME/.local/bin/goreleaser && \
-		rm -f /tmp/goreleaser.tar.gz /tmp/goreleaser; \
-	}
 
 #api-docs: @ Build source code for swagger api reference
 api-docs: deps
@@ -198,7 +144,7 @@ bench-compare: deps
 	fi
 
 #lint: @ Run golangci-lint and hadolint (comprehensive linting via .golangci.yml)
-lint: deps deps-hadolint
+lint: deps
 	@$(call go-exec,golangci-lint run ./...)
 	@hadolint Dockerfile
 
@@ -215,7 +161,7 @@ sec: deps
 	@$(call go-exec,gosec ./...)
 
 #lint-ci: @ Lint GitHub Actions workflow files
-lint-ci: deps deps-shellcheck
+lint-ci: deps
 	@$(call go-exec,actionlint)
 
 #format: @ Format Go code
@@ -223,7 +169,7 @@ format: deps
 	@$(call go-exec,gofmt -l -w .)
 
 #release-check: @ Validate .goreleaser.yml syntax and config
-release-check: deps-goreleaser
+release-check: deps
 	@goreleaser check
 
 #static-check: @ Run code static check
@@ -280,7 +226,7 @@ image-smoke-test:
 image-test: image-build image-smoke-test
 
 #image-scan: @ Build Docker image and run Trivy scan (requires trivy)
-image-scan: deps-trivy build
+image-scan: deps build
 	@docker buildx build --load \
 		--build-arg GOMODCACHE=/go/pkg/mod \
 		--build-arg GOCACHE=/root/.cache/go-build \
@@ -367,7 +313,7 @@ ci: deps format static-check test integration-test coverage-check build fuzz dep
 	@echo "Local CI pipeline passed."
 
 #ci-run: @ Run GitHub Actions workflow locally using act
-ci-run: deps-act
+ci-run: deps
 	@docker container prune -f 2>/dev/null || true
 	@if [ -f ~/.secrets ]; then . ~/.secrets; fi; \
 	act push -W .github/workflows/ci.yml \
@@ -380,16 +326,16 @@ ci-run: deps-act
 check: ci
 	@echo "All pre-commit checks passed."
 
-#trivy-fs: @ Run Trivy filesystem vulnerability scan (requires trivy)
-trivy-fs: deps-trivy
+#trivy-fs: @ Run Trivy filesystem vulnerability scan
+trivy-fs: deps
 	@trivy fs \
 		--scanners vuln,secret,misconfig \
 		--severity CRITICAL,HIGH \
 		--skip-dirs test/node_modules,.pnpm-store \
 		--exit-code 1 .
 
-#trivy-image: @ Run Trivy image vulnerability scan (requires trivy)
-trivy-image: deps-trivy
+#trivy-image: @ Run Trivy image vulnerability scan
+trivy-image: deps
 	@trivy image --severity CRITICAL,HIGH --exit-code 1 $(APP_NAME):scan
 
 #e2e: @ Build + start server + run e2e + stop server (self-contained; called by `make ci`)
@@ -456,7 +402,7 @@ deps-prune-check: deps
 	fi
 	@echo "No prunable dependencies found."
 
-.PHONY: help deps deps-check deps-hadolint deps-shellcheck deps-act deps-trivy deps-goreleaser api-docs test integration-test fuzz bench bench-save bench-compare \
+.PHONY: help deps deps-check api-docs test integration-test fuzz bench bench-save bench-compare \
 	lint vulncheck secrets sec lint-ci format static-check mermaid-lint release-check build run release update open-swagger \
 	test-case-one test-case-two test-case-three e2e e2e-quick clean coverage coverage-check \
 	ci ci-run check trivy-fs trivy-image \

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ C4Context
     Rel(client, flightpath, "POST /calculate", "HTTPS/JSON")
     Rel(flightpath, ghcr, "Published images", "docker push")
     Rel(flightpath, sigstore, "Signed by digest", "cosign OIDC")
+
+    UpdateLayoutConfig($c4ShapeInRow="3")
 ```
 
 See [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md) for Container, Component, request-flow sequence, and CI/CD pipeline diagrams.
@@ -65,16 +67,6 @@ Install all required dev tools:
 make deps
 ```
 
-## API
-
-- **POST /calculate** — accepts `[][]string` flight segments, returns `[]string` (start and end airports)
-- **GET /** — health check
-- **GET /swagger/*** — Swagger UI ([http://localhost:8080/swagger/index.html](http://localhost:8080/swagger/index.html))
-
-Auto-generated OpenAPI spec: [`docs/swagger.json`](./docs/swagger.json)
-
-![Swagger API documentation](./img/swagger-api-doc.jpg)
-
 ## Architecture
 
 Layered Go microservice with a single HTTP endpoint over an in-memory algorithm — no database, no external services.
@@ -101,6 +93,16 @@ flowchart LR
 ```
 
 See [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md) for Container, Component, request-flow sequence, and CI/CD pipeline diagrams.
+
+## API
+
+- **POST /calculate** — accepts `[][]string` flight segments, returns `[]string` (start and end airports)
+- **GET /** — health check
+- **GET /swagger/*** — Swagger UI ([http://localhost:8080/swagger/index.html](http://localhost:8080/swagger/index.html))
+
+Auto-generated OpenAPI spec: [`docs/swagger.json`](./docs/swagger.json)
+
+![Swagger API documentation](./img/swagger-api-doc.jpg)
 
 ## Security & Code Quality
 
@@ -238,13 +240,8 @@ Run `make help` to see all available targets.
 | Target | Description |
 |--------|-------------|
 | `make help` | List available tasks |
-| `make deps` | Install dev tools (swag, golangci-lint, gosec, govulncheck, gitleaks, actionlint, benchstat, newman) via mise + corepack |
+| `make deps` | Install dev tools — `mise install` reads `.mise.toml` and provisions Go, Node, and every quality/security tool (golangci-lint, gosec, govulncheck, gitleaks, actionlint, shellcheck, hadolint, trivy, act, goreleaser). swag + benchstat stay Go-installed; newman via pnpm + corepack |
 | `make deps-check` | Show required Go version, mise status, and tool status |
-| `make deps-hadolint` | Install hadolint for Dockerfile linting |
-| `make deps-shellcheck` | Install shellcheck for shell script linting |
-| `make deps-act` | Install act for running GitHub Actions locally |
-| `make deps-trivy` | Install trivy for local vulnerability scanning |
-| `make deps-goreleaser` | Install goreleaser for `.goreleaser.yml` validation |
 | `make release` | Run full CI pipeline then tag and push a new release |
 | `make open-swagger` | Open browser with Swagger docs pointing to localhost |
 | `make renovate-validate` | Validate Renovate configuration |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,33 +21,38 @@ C4Context
     Rel(user, swagger, "Browses API docs", "HTTP")
     Rel(swagger, flightpath, "Serves from /swagger/*", "HTTP")
     Rel(ci, flightpath, "Builds, tests, scans", "CI pipeline")
+
+    UpdateLayoutConfig($c4ShapeInRow="3")
 ```
 
 ## C4 Container Diagram
 
-Shows the internal containers of the Flight Path API system.
+flight-path ships as **one runnable container** — a statically-linked Go binary
+that embeds the HTTP server, routing, handlers, the `FindItinerary` algorithm,
+and the Swagger UI (via `swaggo/echo-swagger`). The diagram below matches that
+reality. For the internal module structure inside that one container (routes,
+handlers, algorithm, data models) see the Component diagram below.
 
 ```mermaid
 C4Container
     title Container Diagram - Flight Path API
 
-    Person(client, "API Client", "Sends flight segments, receives path")
+    Person(client, "API Client", "cURL, Postman, Newman, browser")
 
     System_Boundary(api, "Flight Path API") {
-        Container(echo, "Echo HTTP Server", "Go 1.26.2, Echo v5.1.0", "Handles HTTP requests, applies middleware, routes to handlers")
-        Container(middleware, "Middleware Stack", "Echo v5.1.0 middleware", "Logger, Recover, CORS, Security Headers, Cache-Control")
-        Container(handlers, "Handlers", "Go 1.26.2", "FlightCalculate, ServerHealthCheck — bind, validate, respond")
-        Container(algorithm, "FindItinerary", "Go 1.26.2", "O(n) algorithm to find start and end airports from flight segments")
-        Container(models, "API Models", "Go 1.26.2", "Flight struct (Start, End), request/response types")
-        Container(swaggerui, "Swagger UI", "swaggo/echo-swagger v2.0.1", "Auto-generated API documentation")
+        Container(server, "flight-path server", "Go 1.26.2, Echo v5.1.0", "Single static binary. Serves POST /calculate, GET /, and GET /swagger/* (embedded Swagger UI via swaggo/echo-swagger v2.0.1). Middleware stack: Logger, Recover, CORS, Secure, Cache-Control, Gzip, RequestID, BodyLimit 1 MiB.")
     }
 
-    Rel(client, echo, "HTTP request", "JSON")
-    Rel(echo, middleware, "Passes through")
-    Rel(middleware, handlers, "Routes to")
-    Rel(handlers, algorithm, "Calls FindItinerary()")
-    Rel(handlers, models, "Uses Flight struct")
-    Rel(echo, swaggerui, "GET /swagger/*")
+    System_Ext(ci, "GitHub Actions CI", "Builds, tests, scans, signs")
+    System_Ext(ghcr, "GHCR", "Hosts multi-arch signed container images")
+    System_Ext(sigstore, "Sigstore", "Cosign keyless OIDC signing + Rekor transparency log")
+
+    Rel(client, server, "POST /calculate, GET /, GET /swagger/*", "HTTPS / JSON")
+    Rel(ci, server, "Builds, tests, image-scans", "make ci / make image-scan")
+    Rel(ci, ghcr, "Publishes images (on tag push)", "docker push")
+    Rel(ci, sigstore, "Signs manifests by digest", "cosign OIDC")
+
+    UpdateLayoutConfig($c4ShapeInRow="3")
 ```
 
 ## C4 Component Diagram

--- a/renovate.json
+++ b/renovate.json
@@ -24,25 +24,13 @@
     },
     {
       "customType": "regex",
-      "description": "Update .mise.toml tool pins via inline renovate comments",
+      "description": "Update .mise.toml tool pins via inline renovate comments (supports plain keys and quoted backend-prefixed keys like \"aqua:owner/name\" or \"go:module/path\")",
       "managerFilePatterns": [
         "/^\\.mise\\.toml$/"
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)( extractVersion=(?<extractVersion>[^\\s]+))?( versioning=(?<versioning>[^\\s]+))?\\n[a-zA-Z_-]+\\s*=\\s*\"(?<currentValue>[^\"]+)\""
+        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)( extractVersion=(?<extractVersion>[^\\s]+))?( versioning=(?<versioning>[^\\s]+))?\\n\"?[a-zA-Z0-9_:./-]+\"?\\s*=\\s*\"(?<currentValue>[^\"]+)\""
       ]
-    },
-    {
-      "customType": "regex",
-      "description": "Update GoReleaser version pinned inline in ci.yml",
-      "managerFilePatterns": [
-        "/^\\.github/workflows/ci\\.yml$/"
-      ],
-      "matchStrings": [
-        "version:\\s*'v(?<currentValue>[^']+)'\\s*# renovate: depName=goreleaser/goreleaser datasource=github-releases"
-      ],
-      "datasourceTemplate": "github-releases",
-      "depNameTemplate": "goreleaser/goreleaser"
     }
   ],
   "postUpdateOptions": [
@@ -58,7 +46,7 @@
   "prHourlyLimit": 0,
   "platformAutomerge": true,
   "automerge": true,
-  "automergeType": "branch",
+  "automergeType": "pr",
   "automergeStrategy": "squash",
   "ignoreTests": false,
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## Summary

Consolidates the project's quality/security tool pins into `.mise.toml` as a single source of truth, migrates CI to `jdx/mise-action`, tightens Renovate, and aligns diagrams + README.

## Changes

### `.mise.toml` / Makefile
- Moved 10 tools from Makefile `_VERSION` constants to `.mise.toml`: `golangci-lint`, `gosec`, `govulncheck`, `gitleaks`, `actionlint`, `shellcheck`, `hadolint`, `trivy`, `act`, `goreleaser`.
- Deleted `deps-hadolint`, `deps-shellcheck`, `deps-act`, `deps-trivy`, `deps-goreleaser` — `mise install` now provisions all of them in one pass.
- `swag` + `benchstat` stay Go-installed (no stable mise backend).
- `PATH` exports `$HOME/.local/share/mise/shims` so mise-managed tools resolve inside every recipe (including under `act`).

### CI (`ci.yml` + `claude-ci-fix.yml`)
- Replaced `actions/setup-go` (7 jobs) and `actions/setup-node` (`e2e` job) with a single `jdx/mise-action@1648a78…` (v4.0.1) step per job.
- Added `actions/cache` for `~/go/pkg/mod` + `~/.cache/go-build` keyed on `go.sum`.
- Dropped the parallel `goreleaser-action` version pin — the mise-installed binary is invoked directly in the `goreleaser` job.

### Renovate (`renovate.json`)
- Extended `.mise.toml` custom-manager regex to match quoted backend-prefixed keys (`"aqua:securego/gosec"`, `"go:golang.org/x/vuln/cmd/govulncheck"`).
- Removed the now-stale inline `goreleaser` customManager.
- **Switched `automergeType` from `branch` to `pr`** — main's ruleset requires the `ci-pass` status check. The old `branch` setting was silently blocking Renovate's direct-push fallback and leaving PRs unmerged.

### Diagrams + README
- Collapsed `docs/ARCHITECTURE.md` Container diagram to one true `Container` (the static Go binary) with external adjacencies on GitHub Actions CI, GHCR, and Sigstore. Fine-grained module structure stays on the Component diagram.
- Added `UpdateLayoutConfig($c4ShapeInRow=3)` to every Context / Container diagram.
- Swapped `## Architecture` above `## API` in README per the narrative-ordering rule.

### CLAUDE.md
- Trimmed Key Variables table (10 fewer entries).
- Rewrote Dev Tools table to mark mise-sourced vs Go-installed tools.
- Refreshed Environment section to document the two PATH entries (`~/.local/bin` for the mise bootstrap + `~/.local/share/mise/shims` for mise-managed tools).

## Test plan

- [x] `make ci` — passes locally (100% coverage, fuzz clean, no prunable deps)
- [x] `make ci-run` — passes under act (`ci-pass` green)
- [x] `make mermaid-lint` — 7/7 blocks parse
- [x] `renovate-validate` — JSON valid, dry-run clean
- [ ] GitHub Actions CI green on this PR