### PR TITLE
docs: sync README, CLAUDE.md, MEMORY.md, and specs/ with current code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,18 @@ actionlint, shellcheck, hadolint, trivy, act, goreleaser) is pinned in
 `mise install --yes`) and CI (`jdx/mise-action`). Do not re-pin these tools in
 the Makefile or workflow YAML.
 
+## Testing Pyramid
+
+Three layers, run in order of increasing cost:
+
+| Layer | Target | Scope | Typical duration |
+|-------|--------|-------|------------------|
+| Unit + handler | `make test` | `go test -race ./...` over unit and handler tests (no HTTP stack) | seconds |
+| Integration | `make integration-test` | `//go:build integration` — full HTTP stack (Echo + middleware + CORS + error envelope) via `httptest` | tens of seconds |
+| End-to-end | `make e2e` | Builds the binary, starts the server, runs the Newman/Postman collection against localhost, tears down | minutes |
+
+`make ci` / `make check` exercises all three plus fuzz and coverage — never skip a layer locally.
+
 ## Before Committing
 
 ```bash

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -9,16 +9,21 @@ description: Project-specific context and knowledge base
 
 ## Architecture Notes
 
-- `FindItinerary()` in `api.go` uses plain maps for source/destination tracking — O(n) time and space
+- `FindItinerary()` in `internal/handlers/api.go` uses plain maps for source/destination tracking — O(n) time and space
 - `Handler` struct is empty (`type Handler struct{}`), DI-ready but no dependencies injected yet
-- Middleware: RequestLogger, Recover, CORS (configurable via `CORS_ORIGIN` env var, defaults to `"*"`), Secure headers
+- Echo bootstrap lives in `internal/app/` (`New()` + `Port()`), shared by `main.go` and integration tests
+- Middleware stack (in order, `internal/app/app.go`): `RequestLogger`, `Recover`, `CORS` (origin from `CORS_ORIGIN` env, defaults to `"*"`), `Secure` (XSS, nosniff, X-Frame-Options: DENY, Referrer-Policy), custom headers (`Cache-Control: no-store`, `Cross-Origin-Resource-Policy: same-origin`)
+- Error envelope uses capital-E `"Error"` key (+ optional `"Index"` for segment errors). Parse/validation errors are 400; 500 is reserved for panics caught by `Recover`
 
 ## Known Tech Debt
 
 - **Test data in public package**: `TestFlights` (19 segments) lives in `pkg/api/data.go` — should move to `internal/` or `_test.go`
-- **CORS wildcard**: `main.go` defaults to `"*"` for allowed origins when `CORS_ORIGIN` is unset
+- **CORS wildcard**: defaults to `"*"` for allowed origins when `CORS_ORIGIN` is unset
+- **IATA validation not enforced**: handler accepts any string for source/destination; only the Postman `successSchema` pins the `^[A-Z]{3}$` shape at the E2E layer
 
 ## CI Pipeline
 
-- Three workflows: `ci.yml` (static-check → builds/tests → integration/dast/image-scan/container-test), `release.yml` (goreleaser on tags via workflow_call), `cleanup-runs.yml` (weekly cleanup)
-- Renovate auto-merges all dependency updates with `chore(all):` prefix
+- Four workflows: `ci.yml` (single-file layout with tag-gated release jobs), `claude.yml` (interactive + auto-review), `claude-ci-fix.yml` (auto-fix on CI failures with anti-recursion guard), `cleanup-runs.yml` (weekly)
+- `ci.yml` jobs: static-check → build/test/integration-test → e2e/dast/docker → (tag-only) goreleaser → ci-pass aggregator
+- No separate `release.yml`; tag-gated behavior is `if: startsWith(github.ref, 'refs/tags/')` on relevant steps inside `ci.yml`
+- Renovate auto-merges low-risk dependency updates with `chore(all):` prefix

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Layered Go microservice with a single HTTP endpoint over an in-memory algorithm 
 | Layer | Location | Responsibility |
 |-------|----------|----------------|
 | Entry point | `main.go` | Load `.env`, construct `App`, start Echo server on `SERVER_PORT` |
-| Bootstrap | `internal/app/` | Wire Echo instance, middleware stack (CORS, Secure, Recover, Cache-Control, Gzip, RequestID, BodyLimit 1 MiB), routes |
+| Bootstrap | `internal/app/` | Wire Echo instance, middleware stack (RequestLogger, Recover, CORS, Secure, Cache-Control/CORP custom headers), routes |
 | Routes | `internal/routes/` | Register method-verb mappings against a `*handlers.Handler` |
 | Handlers | `internal/handlers/` | Bind request, validate, delegate to `FindItinerary`, return JSON |
 | Algorithm | `internal/handlers/api.go` | `FindItinerary` — O(n) reconstruction: build source/destination sets, find unique start (in-degree 0) and end (out-degree 0) airports |
@@ -84,7 +84,7 @@ Layered Go microservice with a single HTTP endpoint over an in-memory algorithm 
 flowchart LR
     client["API Client<br/>(curl / Postman / browser)"]
     subgraph server["flight-path (Echo v5)"]
-        mw["Middleware stack<br/>CORS · Secure · Recover<br/>Cache-Control · Gzip · BodyLimit 1 MiB"]
+        mw["Middleware stack<br/>RequestLogger · Recover · CORS · Secure<br/>Cache-Control · CORP"]
         routes["Routes<br/>POST /calculate<br/>GET /<br/>GET /swagger/*"]
         handlers["Handlers<br/>FlightCalculate<br/>ServerHealthCheck"]
         algo["FindItinerary()<br/>O(n) in-memory graph walk"]

--- a/specs/API.md
+++ b/specs/API.md
@@ -31,8 +31,8 @@ Calculate the flight path from unordered flight segments.
 | Status | Body | Description |
 |---|---|---|
 | 200 | `["SFO", "EWR"]` | `[start_airport, end_airport]` |
-| 400 | `{"Error": "..."}` | Invalid input |
-| 500 | `{"Error": "..."}` | Server/parsing error |
+| 400 | `{"Error": "..."}` | Invalid input (parse error, empty body, incomplete segment) |
+| 500 | `{"Error": "..."}` | Reserved for unexpected server errors (not emitted by current handler) |
 
 **Validation Rules**
 
@@ -40,7 +40,7 @@ Calculate the flight path from unordered flight segments.
 |---|---|---|
 | Empty payload `[]` | 400 | `"Flight segments cannot be empty"` |
 | Segment with < 2 elements | 400 | `"Each flight segment must contain both source and destination"` (includes `Index`) |
-| Unparseable JSON body | 500 | `"Can't parse the payload"` |
+| Unparseable JSON body | 400 | `"Can't parse the payload"` |
 
 **Examples**
 
@@ -90,6 +90,10 @@ Swagger UI for interactive API documentation (auto-generated OpenAPI 2.0 spec).
 
 ## Middleware Stack
 
-1. **RequestLogger** - Logs incoming requests
-2. **Recover** - Recovers from panics, returns 500
-3. **CORS** - Allows all origins (`*`)
+Applied in `internal/app/app.go` in this order:
+
+1. **RequestLogger** — logs incoming requests
+2. **Recover** — recovers from panics, returns 500
+3. **CORS** — `Access-Control-Allow-Origin` from `CORS_ORIGIN` env (defaults to `*`)
+4. **Secure** — sets `X-XSS-Protection: 1; mode=block`, `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: strict-origin-when-cross-origin`
+5. **Cache-Control / CORP** (custom) — adds `Cache-Control: no-store` and `Cross-Origin-Resource-Policy: same-origin` to every response

--- a/specs/ARCHITECTURE.md
+++ b/specs/ARCHITECTURE.md
@@ -23,7 +23,7 @@ Single-service Go REST API using Echo v5, following a layered architecture patte
 │       internal/handlers/          │
 │  handlers.go   Handler struct     │
 │  flight.go     FlightCalculate    │
-│  healthcheck.go HealthCheck       │
+│  healthcheck.go ServerHealthCheck │
 │  api.go        FindItinerary      │
 └───────────────┬──────────────────┘
                 │
@@ -47,8 +47,12 @@ flight-path/
 │   │   ├── api.go                   # FindItinerary algorithm (O(n), plain maps)
 │   │   ├── api_test.go              # Unit tests for FindItinerary
 │   │   ├── api_bench_test.go        # Benchmarks for FindItinerary
+│   │   ├── api_fuzz_test.go         # Fuzz tests for FindItinerary
 │   │   ├── flight_test.go           # Handler tests for FlightCalculate
 │   │   └── healthcheck_test.go      # Handler tests for ServerHealthCheck
+│   └── app/                        # Echo bootstrap (middleware + routes)
+│       ├── app.go                   # New() builds Echo, Port() returns SERVER_PORT
+│       └── app_integration_test.go  # //go:build integration — full HTTP stack
 │   └── routes/                      # Route registration
 │       ├── flight.go                # Flight routes
 │       ├── healthcheck.go           # Health routes
@@ -58,9 +62,9 @@ flight-path/
 │   └── version.txt                  # Semantic version
 ├── docs/                            # Auto-generated Swagger (do not edit)
 ├── specs/                           # Reverse-engineered specifications
-├── test/                            # E2E test collections (6 cases)
+├── test/                            # Newman/Postman E2E collection (18 cases)
 ├── benchmarks/                      # Saved benchmark results
-├── scripts/                         # Build/deploy scripts
+├── scripts/                         # Build + wait-for-server helpers
 ├── .github/workflows/               # CI/CD pipelines
 ├── Dockerfile                       # Multi-stage container build
 ├── Makefile                         # Build automation
@@ -87,16 +91,28 @@ Routes in `internal/routes/` receive `*handlers.Handler` and wire methods.
 
 | Layer | Location | Responsibility |
 |---|---|---|
-| Entry point | `main.go` | Server bootstrap, middleware, config |
+| Entry point | `main.go` | Parse flags, load `.env`, call `app.New()`, start server on `app.Port()` |
+| Bootstrap | `internal/app/` | Build Echo instance, register middleware + routes (shared by `main.go` and integration tests) |
 | Routes | `internal/routes/` | URL-to-handler mapping |
 | Handlers | `internal/handlers/*.go` | HTTP binding, validation, response |
-| Business logic | `internal/handlers/api.go` | Core algorithm |
+| Business logic | `internal/handlers/api.go` | Core algorithm (`FindItinerary`) |
 | Data models | `pkg/api/` | Shared types and fixtures |
+
+### Middleware Stack
+
+Registered in `internal/app/app.go` in this order:
+
+1. `RequestLogger` — request access log
+2. `Recover` — panic → 500
+3. `CORS` — `CORS_ORIGIN` env var (defaults to `*`)
+4. `Secure` — XSS, nosniff, X-Frame-Options: DENY, Referrer-Policy: strict-origin-when-cross-origin
+5. Custom headers — `Cache-Control: no-store`, `Cross-Origin-Resource-Policy: same-origin`
 
 ### Configuration
 
 - `.env` loaded via `godotenv`, overridable with `--env-file` flag
-- Single config: `SERVER_PORT` (default `8080`)
+- `SERVER_PORT` — server port (default `8080`)
+- `CORS_ORIGIN` — single allowed origin for CORS (default `*`)
 
 ## Dependencies
 

--- a/specs/BUILD.md
+++ b/specs/BUILD.md
@@ -2,16 +2,26 @@
 
 ## Toolchain
 
-| Tool | Version | Purpose |
+Go and Node are provisioned by [mise](https://mise.jdx.dev/) from `.mise.toml` (plus `go.mod` for Go). Every quality/security tool below is also pinned in `.mise.toml` as a single source of truth, consumed by both `make deps` locally and `jdx/mise-action` in CI.
+
+| Tool | Source of truth | Purpose |
 |---|---|---|
-| Go | 1.26.2 (via gvm) | Language runtime |
-| Node.js | LTS (via nvm) | Newman E2E test runner |
-| golangci-lint | latest | Linting |
-| go-critic | latest | Code review |
-| gosec | latest | Security scanning |
-| swag | latest | Swagger generation |
-| benchstat | latest | Benchmark comparison |
-| newman | latest (pnpm) | Postman collection runner |
+| Go | `go.mod` + `.mise.toml` | Language runtime (currently 1.26.2) |
+| Node.js | `.nvmrc` + `.mise.toml` | Newman E2E runner (currently major 24) |
+| golangci-lint | `.mise.toml` | Meta-linter (configured via `.golangci.yml`) |
+| gosec | `.mise.toml` (aqua:securego/gosec) | Security scanner |
+| govulncheck | `.mise.toml` (go: backend) | Dependency vulnerability check |
+| gitleaks | `.mise.toml` | Secret detection |
+| actionlint | `.mise.toml` | GitHub Actions linter |
+| shellcheck | `.mise.toml` | Shell script linter (invoked by actionlint) |
+| hadolint | `.mise.toml` | Dockerfile linter |
+| trivy | `.mise.toml` | Image + filesystem vulnerability scanner |
+| act | `.mise.toml` | Local GitHub Actions runner |
+| goreleaser | `.mise.toml` | Release binary builder + `.goreleaser.yml` validator |
+| swag | Go install pinned via `SWAG_VERSION` in `Makefile` | Swagger code generator (no stable mise backend) |
+| benchstat | Go install pinned via `BENCHSTAT_VERSION` in `Makefile` | Benchmark comparison |
+| newman | `pnpm install` in `test/` (pinned in `test/package.json`) | Postman collection runner |
+| mermaid-cli | Docker image pinned via `MERMAID_CLI_VERSION` in `Makefile` | Mermaid diagram validator |
 
 ## Build Flags
 
@@ -22,46 +32,44 @@ GOOS=linux
 GOARCH=amd64
 ```
 
+The Docker image build additionally honors `TARGETOS` / `TARGETARCH` for cross-compilation (see `DOCKER.md`).
+
 ## Dependency Installation (`make deps`)
 
-Installs all missing tools using `command -v` checks:
+1. Install `mise` if not on `PATH`
+2. `mise install --yes` — provisions Go, Node, and every tool pinned in `.mise.toml`
+3. `go install` for `swag` and `benchstat` (no stable mise backend)
+4. Enable `corepack` and `pnpm install` in `test/` for Newman
 
-1. **swag** -- `go install github.com/swaggo/swag/cmd/swag@latest`
-2. **gosec** -- `go install github.com/securego/gosec/v2/cmd/gosec@latest`
-3. **benchstat** -- `go install golang.org/x/perf/cmd/benchstat@latest`
-4. **golangci-lint** -- via install script
-5. **Node.js** -- `nvm install --lts && nvm use --lts` (if node not found)
-6. **newman** -- `cd test && pnpm install`
+`make deps-check` reports the Go version, mise status, and which tools resolve on `PATH`.
 
 ## Build Pipeline (`make build`)
 
 ```
-deps → lint → critic → sec → api-docs → compile
+api-docs → go build
 ```
 
-1. **deps** -- Install missing tools
-2. **lint** -- `golangci-lint run ./...`
-3. **critic** -- `gocritic check -enableAll ./...`
-4. **sec** -- `gosec ./...`
-5. **api-docs** -- `swag init --parseDependency -g main.go`
-6. **compile** -- `go build -a -o server main.go` (static binary)
+1. **api-docs** — `swag init --parseDependency -g main.go` regenerates `docs/swagger.{json,yaml,go}` from handler annotations
+2. **go build** — `go build -a -o server main.go` (static binary via `CGO_ENABLED=0`)
+
+Upstream quality/security gates (lint, sec, vulncheck, secrets, trivy-fs, mermaid-lint, release-check) live in `make static-check` and are not prerequisites of `make build` — they run in their own CI job and in `make ci`.
 
 ## Run Locally
 
 ```bash
-make run    # build + go run main.go -env-file .env
+make run    # go build + ./server
 ```
 
 ## Output Artifacts
 
 | Artifact | Location |
 |---|---|
-| `server` | Project root (Linux amd64 binary) |
-| `docs/swagger.json` | Generated OpenAPI 2.0 spec |
+| `server` | Project root (statically linked binary; `GOOS`/`GOARCH` honored) |
+| `docs/swagger.json` | Generated OpenAPI 2.0 spec (swag v2 still emits swagger 2.0) |
 | `docs/swagger.yaml` | Generated OpenAPI 2.0 spec (YAML) |
-| `docs/docs.go` | Go embed for Swagger |
+| `docs/docs.go` | Go embed used by `swaggo/echo-swagger/v2` |
 
 ## Version Management
 
-- Stored in `pkg/api/version.txt` (currently `v0.0.3`)
-- Updated during `make release`
+- Stored in `pkg/api/version.txt`
+- Bumped during `make release`, which runs the full CI pipeline, tags, and pushes to trigger the tag-gated release jobs in `.github/workflows/ci.yml`

--- a/specs/CI-CD.md
+++ b/specs/CI-CD.md
@@ -1,53 +1,76 @@
 # CI/CD Specification
 
-## CI Pipeline (`.github/workflows/ci.yml`)
+Every CI job and the full release pipeline live in a single workflow file (`.github/workflows/ci.yml`), with tag-gated sibling jobs for the release phase. Supporting workflows (`claude.yml`, `claude-ci-fix.yml`, `cleanup-runs.yml`) are separate.
 
-**Triggers**: All pushes and pull requests
+## `ci.yml`
 
-```
-static-check → builds → tests → integration
-```
+### Triggers
 
-### static-check (10min timeout)
-- `make deps lint critic sec`
+- Push to `main`
+- Push of tags matching `v*`
+- Pull requests targeting `main`
 
-### builds (10min timeout, depends: static-check)
-- Setup Go from `go.mod`
-- `make build`
+`paths-ignore` excludes documentation, images, benchmarks, `.claude/**`, and other non-critical files; `CLAUDE.md` is re-included via `!CLAUDE.md`. Tags are unaffected by `paths-ignore`.
 
-### tests (depends: builds)
-- Matrix: `[unit]`
-- `make test`
+### Permissions
 
-### integration (20min timeout, depends: builds + tests)
-- Setup Go + Node.js (LTS)
-- Install Newman
-- `make build`
-- Start server in background (`go run main.go -env-file .env &`)
-- Wait 6 seconds
-- `make e2e` (Newman/Postman E2E tests)
+Default `contents: read`. Elevated permissions are scoped per job that needs them — e.g. the `docker` job sets `packages: write` + `id-token: write` on the steps that push and sign.
 
-**Permissions**: `contents: write`, `packages: write`
+### Jobs
 
-## Release Pipeline (`.github/workflows/release.yml`)
+| Job | Triggers | Depends on | Timeout | Steps |
+|---|---|---|---|---|
+| **static-check** | all | — | 15 min | `mise install`, `make static-check` (lint-ci + lint + sec + vulncheck + secrets + trivy-fs + mermaid-lint + release-check) |
+| **build** | all | static-check | 10 min | `go build`, upload `server-binary` artifact |
+| **test** | all | static-check | 15 min | `make coverage-check` (80% floor), upload coverage artifact |
+| **integration-test** | all | static-check | 10 min | `make integration-test` — full HTTP stack via `httptest` and `//go:build integration` |
+| **e2e** | all | build, test | 15 min | Download binary (fallback: rebuild when artifact download fails), start server, run Newman collection. Runs identically under `act` via `make ci-run`. |
+| **dast** | all except under `act` (`vars.ACT == 'true'` skips) | build, test | 15 min | Download binary, start server, run OWASP ZAP API scan against `swagger.json`. Skipped in `act` because ZAP needs Docker-in-Docker. |
+| **docker** | all | static-check, build, test | 30 min | Gate 1–3 every push (build, Trivy image scan, smoke test). Gate 4 multi-arch build every push; push only when `startsWith(github.ref, 'refs/tags/')`. Gate 5 cosign signing tag-only. |
+| **goreleaser** | tag push only | all above | 30 min | GoReleaser builds binaries, archives, checksums, changelog; creates the GitHub Release |
+| **ci-pass** | always | every upstream job | — | Aggregator with `if: always()`; fails only when `contains(needs.*.result, 'failure')`. Single required check for branch protection. On non-tag pushes, `goreleaser` is `skipped` (not `failure`) and the aggregator still passes. |
 
-**Triggers**: Tag push (`*`)
+### Required secrets
 
-1. Checkout + Setup Go (from `go.mod`)
-2. Docker login to GHCR (`ghcr.io`)
-3. GoReleaser (`goreleaser/goreleaser-action@v7`) with `.goreleaser.yml`
+| Secret | Used by | How to obtain |
+|---|---|---|
+| `GITHUB_TOKEN` | all jobs that touch Actions artifacts, GHCR, releases | Auto-injected by GitHub Actions |
+| `CLAUDE_CONFIG_TOKEN` | `claude.yml`, `claude-ci-fix.yml` | PAT with `contents: read` on `AndriyKalashnykov/claude-config` so those workflows can check out shared config |
+| `ANTHROPIC_API_KEY` | `claude.yml`, `claude-ci-fix.yml` | [console.anthropic.com](https://console.anthropic.com/) API key |
 
-**Secrets**: `GH_ACCESS_TOKEN` (GHCR), `GITHUB_TOKEN` (GoReleaser)
+### Repository variables
 
-## Release Process (`make release`)
+| Variable | Purpose |
+|---|---|
+| `ACT` | Set to `"true"` locally via `make ci-run --var ACT=true` to skip the `dast` job. Not set on GitHub-hosted runners. |
 
-1. `make api-docs build`
-2. Prompt for new tag
-3. Write to `pkg/api/version.txt`
-4. `git add -A && git commit -a -s -m "Cut {tag} release"`
-5. `git tag {tag} && git push origin {tag} && git push`
-6. GitHub Actions release workflow triggers
+## Release process (`make release`)
 
-## Dependency Automation
+1. `make ci` — run the full local pipeline
+2. Prompt for new tag, write to `pkg/api/version.txt`
+3. `git commit -a -s -m "Cut <tag> release"`
+4. `git tag <tag> && git push origin <tag> && git push`
+5. GitHub Actions runs `ci.yml` on the tag — static-check, build, test, integration-test, e2e, dast, docker (including GHCR push + cosign sign), goreleaser — then `ci-pass` aggregates
 
-Renovate (`renovate.json`) for automated dependency update PRs.
+There is no separate `release.yml`. Tag-only behavior is implemented via `if: startsWith(github.ref, 'refs/tags/')` on the relevant steps inside `ci.yml`.
+
+## `claude.yml`
+
+Interactive Claude workflow — responds to `@claude` mentions in issues/PRs and performs automated PR reviews on every non-draft PR. Restricted to `author_association` in `{OWNER, MEMBER, COLLABORATOR}`. Uses `CLAUDE_CONFIG_TOKEN` + `ANTHROPIC_API_KEY`.
+
+## `claude-ci-fix.yml`
+
+Auto-triggers on CI failures via `workflow_run` for same-repo PR branches. Attempts to produce a fix commit. Dual anti-recursion guard:
+
+1. Bot-author check — skip if the failing run was authored by the bot itself
+2. `claude-fix-attempted` label — skip if already attempted on this PR
+
+Caps total CI-log input at 12K characters to prevent prompt-injection context stuffing.
+
+## `cleanup-runs.yml`
+
+Scheduled weekly (Sundays 00:00 UTC). Deletes workflow runs older than 7 days, keeps a minimum of 5, and prunes caches on merged or deleted branches.
+
+## Dependency automation
+
+Renovate (`renovate.json`) raises PRs for all tracked dependencies with platform automerge enabled for low-risk updates (minor/patch, pin updates, Docker digest refresh).

--- a/specs/DATA-MODELS.md
+++ b/specs/DATA-MODELS.md
@@ -27,14 +27,16 @@ Go type: `[][]string`
 ```
 Go type: `[]string` -- index 0 = start, index 1 = end
 
-### Error Responses (400/500)
+### Error Responses (400)
 
 ```json
 {"Error": "descriptive message"}
 ```
 Segment errors include index: `{"Error": "...", "Index": 2}`
 
-Go type: `map[string]any`
+Go type: `map[string]any`. Note the capital-E `"Error"` key — this is the current contract enforced by Postman Ajv `errorSchema` validation.
+
+A `500` status code is reserved for unexpected server errors (e.g., panics caught by `middleware.Recover`); it is not emitted by normal validation failures.
 
 ### GET / Health Response (200)
 
@@ -52,9 +54,9 @@ Go type: `map[string]any`
 
 | Rule | Status | Error |
 |---|---|---|
-| Parseable JSON | 500 | "Can't parse the payload" |
+| Parseable JSON | 400 | "Can't parse the payload" |
 | Non-empty array | 400 | "Flight segments cannot be empty" |
-| Segment >= 2 elements | 400 | "Each flight segment must contain both source and destination" |
+| Segment >= 2 elements | 400 | "Each flight segment must contain both source and destination" (includes `Index`) |
 
 ## Validation (not implemented)
 
@@ -68,6 +70,6 @@ Go type: `map[string]any`
 
 ### TestFlights (`pkg/api/data.go`)
 
-19-segment chain: `BGY → RAR → AUH → FCO → BCN → PSC → BLQ → MAD → SFO → ATL → GSO → IND → EWR → CHI → JFK → AAL → HEL → CAK → BJZ → AKL`
+19-segment chain: `BGY → RAR → AUH → FCO → BCN → PSC → BLQ → MAD → SFO → ATL → GSO → IND → EWR → CHI → JFK → AAL → HEL → CAK → BJZ → AKL`.
 
-Start: BGY, End: AKL (currently unused by any test)
+Start: BGY, End: AKL. Stored in the source in shuffled order to exercise the algorithm's unordered-input behavior.

--- a/specs/DOCKER.md
+++ b/specs/DOCKER.md
@@ -4,40 +4,77 @@
 
 ### Stage 1: Build (`golang:1.26-alpine`)
 
-- Base: `golang:1.26-alpine` (SHA256-pinned)
+- Base: `golang:1.26-alpine` (SHA256-pinned, Renovate-tracked via inline comment in `Dockerfile`)
 - Mount caches for `GOMODCACHE` and `GOCACHE`
 - Cross-compile: `CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH`
 - Output: `/app/main`
 
 ### Stage 2: Runtime (`alpine:3.23.3`)
 
-- Base: `alpine:3.23.3` (SHA256-pinned)
+- Base: `alpine:3.23.3` (SHA256-pinned, Renovate-tracked)
 - Non-root user: `srvuser:srvgroup` (UID/GID 1000)
+- `HEALTHCHECK` hits `localhost:${SERVER_PORT:-8080}` (no `EXPOSE` directive — port is honored only at runtime via env)
 - Binary copied from build stage
 - Entrypoint: `["./main"]`
 
-## Build Script (`scripts/build-image.sh`)
+## Build & Publish
+
+Image builds use `docker buildx` directly (invoked by Makefile targets and the `docker` CI job — no separate build script).
 
 | Parameter | Value |
 |---|---|
-| Registry | `andriykalashnykov` (Docker Hub) |
-| Image | `flight-path:latest` |
-| Platforms | `linux/amd64`, `linux/arm64`, `linux/arm/v7` |
-| Builder | Docker buildx (creates if missing) |
+| Registry | `ghcr.io/andriykalashnykov` (GitHub Container Registry) |
+| Image | `ghcr.io/andriykalashnykov/flight-path:<tag>` |
+| Platforms | `linux/amd64`, `linux/arm64` |
+| Multi-arch pattern | Pattern A: `provenance: false` + `sbom: false` — yields a clean image index so the GHCR "OS / Arch" tab renders without `unknown/unknown` rows |
+| Signing | Cosign keyless OIDC (`sigstore/cosign-installer` + `cosign sign --yes <digest>`), tag-gated |
 
-```bash
-make image-build    # deps + lint + critic + sec + api-docs + build-image.sh
-```
+### Makefile targets
+
+| Target | Purpose |
+|---|---|
+| `make image-build` | Single-arch local build (loaded into the host Docker daemon) |
+| `make image-run` / `make image-stop` | Start/stop a detached container for local probing |
+| `make image-push` | Push to GHCR (requires `GH_ACCESS_TOKEN`; `GHCR_USER` defaults to `git config user.name`) |
+| `make image-smoke-test` | Start container, assert `GET /` and `POST /calculate` return 200, tear down |
+| `make image-test` | `image-build` + `image-smoke-test` |
+| `make image-scan` | Build image and run Trivy |
+| `make trivy-fs` | Filesystem vulnerability scan (uses `.trivyignore` if present) |
+| `make trivy-image` | Image vulnerability scan |
+
+### CI gates (`docker` job in `.github/workflows/ci.yml`)
+
+The `docker` job runs on every push. Gates 1–3 run unconditionally; Gate 4 builds multi-arch on every push and only pushes on tag. Gate 5 is tag-only.
+
+| # | Gate | What it catches |
+|---|---|---|
+| 1 | Single-arch build + `load: true` | Build regressions on runner architecture |
+| 2 | Trivy image scan (CRITICAL/HIGH blocking) | CVEs, secrets, misconfigs in base + build layers |
+| 3 | `make image-smoke-test` | Image boots, endpoints respond |
+| 4 | Multi-arch buildx (`linux/amd64`, `linux/arm64`); push on tags only | Cross-compile regressions even on non-tag pushes |
+| 5 | Cosign keyless OIDC signing (tag only) | Sigstore signature on the manifest digest |
 
 ## Running
 
 ```bash
-docker run -p 8080:8080 andriykalashnykov/flight-path:latest
+docker run -p 8080:8080 ghcr.io/andriykalashnykov/flight-path:<tag>
+```
+
+## Inspection & Verification
+
+```bash
+# Inspect multi-arch manifest (expect amd64 + arm64, no unknown/unknown rows)
+docker buildx imagetools inspect ghcr.io/andriykalashnykov/flight-path:<tag>
+
+# Verify cosign signature
+cosign verify ghcr.io/andriykalashnykov/flight-path:<tag> \
+  --certificate-identity-regexp 'https://github\.com/AndriyKalashnykov/flight-path/\.github/workflows/ci\.yml@refs/tags/v.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
 
 ## Notes
 
-- `.env` is NOT in runtime image (only binary is copied)
-- `SERVER_PORT` defaults to `8080` if unset
+- `.env` is NOT copied into the runtime image — only the binary
+- `SERVER_PORT` defaults to `8080` when unset
 - Container runs as non-root (UID 1000)
-- Commented alternatives in Dockerfile: Red Hat UBI 9, Google Distroless
+- Commented alternatives in `Dockerfile`: Red Hat UBI 9, Google Distroless

--- a/specs/PRODUCT.md
+++ b/specs/PRODUCT.md
@@ -37,12 +37,13 @@ The API must provide auto-generated Swagger/OpenAPI documentation accessible via
 ### NFR-2: Portability
 
 - The service must run as a standalone binary (Linux amd64)
-- The service must be containerized for multi-platform deployment (amd64, arm64, arm/v7)
+- The service must be containerized for multi-platform deployment (`linux/amd64`, `linux/arm64`)
 
 ### NFR-3: Code Quality
 
-- Static analysis (golangci-lint, go-critic, gosec) must pass before builds
-- E2E tests must pass in CI before merging
+- Static analysis (`golangci-lint`, `gosec`, `govulncheck`, `gitleaks`, `hadolint`, `trivy`) must pass before builds
+- Unit + integration + E2E tests must pass in CI before merging
+- Coverage must stay at or above 80% (`make coverage-check`)
 
 ### NFR-4: Observability
 

--- a/specs/TESTING.md
+++ b/specs/TESTING.md
@@ -1,8 +1,12 @@
 # Testing Specification
 
-## 1. Unit Tests — Algorithm
+Three test layers, from fastest to most realistic. All three run in CI and in `make ci` / `make check`.
 
-**Location**: `internal/handlers/api_test.go`
+## Layer 1 — Unit & Handler Tests (`make test`)
+
+`go test -race -v ./...`. Runs in seconds.
+
+### Algorithm — `internal/handlers/api_test.go`
 
 | Test | Input | Expected |
 |---|---|---|
@@ -11,11 +15,9 @@
 | two flights in order | `[SFO->ATL, ATL->EWR]` | `("SFO", "EWR")` |
 | two flights reversed | `[ATL->EWR, SFO->ATL]` | `("SFO", "EWR")` |
 | four flights shuffled | 4-segment path | `("SFO", "EWR")` |
-| TestFlights fixture | 19 segments | `("BGY", "AKL")` |
+| TestFlights fixture | 19 segments, shuffled | `("BGY", "AKL")` |
 
-## 2. Unit Tests — Handlers
-
-**Location**: `internal/handlers/flight_test.go`
+### Handler — `internal/handlers/flight_test.go`
 
 | Test | Input | Expected Status |
 |---|---|---|
@@ -24,18 +26,74 @@
 | four segments | 4-segment path | 200 |
 | empty array | `[]` | 400 |
 | incomplete segment | `[["SFO"]]` | 400 |
-| malformed JSON | `not json` | 500 |
+| malformed JSON | `not json` | 400 |
 | empty body | `` | 400 |
 
-**Location**: `internal/handlers/healthcheck_test.go`
+### Health — `internal/handlers/healthcheck_test.go`
 
 | Test | Expected |
 |---|---|
 | GET / | 200, `{"data": "Server is up and running"}` |
 
-## 3. Benchmark Tests
+### Coverage gate
 
-**Location**: `internal/handlers/api_bench_test.go`
+`make coverage-check` fails the build when total coverage drops below 80%.
+
+## Layer 2 — Integration Tests (`make integration-test`)
+
+`go test -race -tags=integration -v ./internal/app/...`. Runs in tens of seconds.
+
+**Location**: `internal/app/app_integration_test.go` (build tag `//go:build integration`).
+
+Exercises the full `app.New()` bootstrap — middleware chain, CORS branches, security headers, error envelope, preflight `OPTIONS`, panic recovery — via `httptest`. Covers the surface area Layer 1 intentionally skips (middleware, route registration, `HTTPErrorHandler`).
+
+## Layer 3 — End-to-End Tests (`make e2e` / `make e2e-quick`)
+
+`make e2e` is self-contained: it builds the binary, starts the server on `SERVER_PORT`, runs the Newman collection against `localhost`, then tears the server down. `make e2e-quick` skips the build/start/stop steps and runs Newman against an already-running server.
+
+**Location**: `test/FlightPath.postman_collection.json` — 18 test cases.
+
+### Validation strategy
+
+Hybrid — [Ajv](https://ajv.js.org/) JSON Schema validation for response structure plus [Chai](https://www.chaijs.com/) assertions for exact business values:
+
+- **Collection pre-request**: defines two global schemas (`successSchema`, `errorSchema`) stored via `pm.globals`
+- **Collection test**: Ajv validates every `/calculate` response against the appropriate schema (selected by status code). Non-`/calculate` requests (HealthCheck, Swagger_UI) skip the collection-level schema check so their request-level tests run in isolation
+- **Request tests**: status code + business value assertions (start/end airports, header presence, error message substring)
+
+### Global schemas
+
+| Schema | Type | Constraints |
+|---|---|---|
+| `successSchema` | `array` | Exactly 2 items, each a 3-letter uppercase string (`^[A-Z]{3}$`) |
+| `errorSchema` | `object` | Required `Error` (string, minLength 1), optional `Index` (integer), no additional properties |
+
+### Cases
+
+| Test | Input / Scope | Expected |
+|---|---|---|
+| HealthCheck | `GET /` | 200, `{"data": ...}` |
+| UseCase01 | `[["SFO","EWR"]]` | 200, `["SFO","EWR"]` |
+| UseCase02 | `[["ATL","EWR"],["SFO","ATL"]]` | 200, `["SFO","EWR"]` |
+| UseCase03 | 4-segment path | 200, `["SFO","EWR"]` |
+| UseCase04_EmptyBody | `[]` | 400, error contains "empty" |
+| UseCase05_MalformedJSON | `not valid json` | 400, error contains "parse" |
+| UseCase06_IncompleteSegment | `[["SFO"]]` | 400, error contains "source and destination" |
+| UseCase07_ExtraItemsInSegmentIgnored | `[["SFO","EWR","JFK"]]` | 200, first two elements used |
+| UseCase08_TenSegmentChain | 10 scrambled segments | 200, resolves LAX→SFO |
+| UseCase09_ObjectRoot | `{"foo":"bar"}` | 400, error contains "parse" |
+| UseCase10_SecondSegmentIncomplete | `[["SFO","EWR"],["JFK"]]` | 400 with `Index: 1` |
+| HealthCheck_SecurityHeaders | `GET /` | asserts `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy` |
+| HealthCheck_CORS | `OPTIONS /` | default `Access-Control-Allow-Origin: *` |
+| Swagger_UI | `GET /swagger/index.html` | 200, HTML |
+| UseCase11_WrongMethod | `GET /calculate` | 405 |
+| UseCase12_UnknownRoute | `GET /does-not-exist` | 404 |
+| UseCase13_LargeChain | 100-segment chain | 200 |
+| UseCase14_WrongContentType | `text/plain` body | 400, error contains "content-type" |
+
+## Layer 4 — Benchmarks
+
+`internal/handlers/api_bench_test.go`:
 
 | Benchmark | Dataset |
 |---|---|
@@ -44,55 +102,17 @@
 | `BenchmarkFindItinerary_100` | 100 flights |
 | `BenchmarkFindItinerary_500` | 500 flights |
 
-Benchmarks test production `FindItinerary` directly (O(n) algorithm).
-
 ```bash
-make bench          # Run benchmarks (3s each)
-make bench-save     # Save to benchmarks/bench_YYYYMMDD_HHMMSS.txt
-make bench-compare  # Compare latest two with benchstat
+make bench          # run benchmarks
+make bench-save     # save to benchmarks/bench_YYYYMMDD_HHMMSS.txt
+make bench-compare  # auto-discover latest two files and diff with benchstat
 ```
 
-## 4. E2E Tests (Postman/Newman)
+## Layer 5 — Fuzz
 
-**Location**: `test/FlightPath.postman_collection.json`
-**Prerequisite**: Server running on `localhost:8080`
+`internal/handlers/api_fuzz_test.go` — run for 30 s via `make fuzz` (`go test -fuzz=. -fuzztime=30s`).
 
-### Validation Strategy
-
-Hybrid approach — Ajv JSON Schema validation for response structure, Chai assertions for exact values:
-
-- **Collection pre-request**: Defines two global JSON schemas (`successSchema`, `errorSchema`) stored via `pm.globals`
-- **Collection test**: Ajv validates every response against the appropriate schema (auto-selected by status code)
-- **Request tests**: Status code check + business value assertions
-
-#### Global Schemas
-
-| Schema | Type | Constraints |
-|---|---|---|
-| `successSchema` | `array` | Exactly 2 items, each a 3-letter uppercase string (`^[A-Z]{3}$`) |
-| `errorSchema` | `object` | Required `Error` (string, minLength 1), optional `Index` (integer), no additional properties |
-
-### Happy Path Cases
-
-| Test | Input | Expected |
-|---|---|---|
-| UseCase01 | `[["SFO", "EWR"]]` | `["SFO", "EWR"]` |
-| UseCase02 | `[["ATL", "EWR"], ["SFO", "ATL"]]` | `["SFO", "EWR"]` |
-| UseCase03 | 4-segment path | `["SFO", "EWR"]` |
-
-### Negative Cases
-
-| Test | Input | Expected Status | Error Contains |
-|---|---|---|---|
-| UseCase04_EmptyBody | `[]` | 400 | "empty" |
-| UseCase05_MalformedJSON | `not valid json` | 400 | "parse" |
-| UseCase06_IncompleteSegment | `[["SFO"]]` | 400 | "source and destination" |
-
-```bash
-make e2e    # newman run ./test/FlightPath.postman_collection.json
-```
-
-## 5. Manual curl Tests
+## Manual curl Tests
 
 ```bash
 make test-case-one      # [["SFO", "EWR"]]
@@ -100,13 +120,9 @@ make test-case-two      # [["ATL", "EWR"], ["SFO", "ATL"]]
 make test-case-three    # 4-segment path
 ```
 
+These are optional convenience targets for hand-checking a running server; they are not part of CI.
+
 ## Test Data
 
-**Static fixture**: `pkg/api/data.go` -- `TestFlights` (19 segments, BGY -> AKL). Used by `TestFindItinerary`.
-**Synthetic**: `generateFlights(n)` in bench test -- creates chain using sequential runes.
-
-## Running All Tests
-
-```bash
-make test   # go generate && go test -v ./...
-```
+- **Static fixture**: `pkg/api/data.go` → `TestFlights` (19 segments, BGY → AKL, stored shuffled)
+- **Synthetic**: `generateFlights(n)` in the benchmark test — creates a chain using sequential runes


### PR DESCRIPTION
## Summary

Audit found substantial drift across 11 markdown files; fixes restore alignment with the current code, Makefile, `.mise.toml`, and `.github/workflows/ci.yml`.

### specs/ rewrites & fixes

- **BUILD.md** — replaced gvm/nvm with mise; removed `go-critic`; added `govulncheck`, `gitleaks`, `actionlint`, `shellcheck`, `hadolint`, `trivy`, `act`, `goreleaser`, `mermaid-cli`, `newman`
- **CI-CD.md** — matches single-file `ci.yml` layout with all 9 jobs (static-check, build, test, integration-test, e2e, dast, docker, goreleaser, ci-pass); documented Claude workflows + cleanup-runs; fixed permissions to `contents: read`; replaced stale `GH_ACCESS_TOKEN` with `CLAUDE_CONFIG_TOKEN` + `ANTHROPIC_API_KEY`; removed non-existent `release.yml` reference
- **TESTING.md** — explicit three-layer pyramid (unit + handler / integration via `//go:build integration` / Newman E2E); expanded Newman table from 3 to all 18 cases; fixed malformed-JSON status to 400; added fuzz layer
- **DOCKER.md** — platforms reduced to `linux/amd64` + `linux/arm64` (dropped `arm/v7`); registry → `ghcr.io`; removed stale `scripts/build-image.sh` section; documented the 5 CI gates with cosign details
- **API.md** — parse error is 400 (not 500); rewrote middleware stack to match `internal/app/app.go` (RequestLogger, Recover, CORS, Secure, custom Cache-Control/CORP — no BodyLimit, Gzip, or RequestID)
- **DATA-MODELS.md** — parse error is 400; clarified capital-E `"Error"` key contract; TestFlights noted as shuffled
- **ARCHITECTURE.md** — `HealthCheck` → `ServerHealthCheck`; added `internal/app/` + `api_fuzz_test.go`; corrected `test/` case count 6 → 18; added middleware stack + `CORS_ORIGIN` env var
- **PRODUCT.md** — dropped `arm/v7` + `go-critic` from NFRs; expanded static-analysis + testing requirements

### README.md & CLAUDE.md

- Fixed stale middleware description (removed Gzip, RequestID, BodyLimit; added RequestLogger + CORP) in both the Architecture table and the Mermaid diagram
- CLAUDE.md gained an explicit Testing Pyramid section (unit/integration/e2e with time scales)

### MEMORY.md

- Four workflows (not three); tag-gated release jobs live inside `ci.yml`; capital-E `Error` envelope; IATA validation not enforced at handler layer

## Test plan

- [x] `make mermaid-lint` passes on README.md and docs/ARCHITECTURE.md after edits
- [ ] CI (`ci-pass`) green