### PR TITLE
ci: switch to dorny/paths-filter, serialize release jobs, name uses-steps

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -16,7 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Enable auto-merge (squash)
+        # `--repo` is required because the job has no `actions/checkout` step,
+        # so cwd is not a git repo and `gh pr merge` cannot auto-detect the
+        # remote — without this flag every run fails with
+        # `fatal: not a git repository`.
         env:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.pull_request.number }}
-        run: gh pr merge "$PR" --auto --squash
+          REPO: ${{ github.repository }}
+        run: gh pr merge "$PR" --auto --squash --repo "$REPO"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,35 +4,7 @@ on:
   push:
     branches: [main]
     tags: ['v*']
-    paths-ignore:
-      - '*.md'
-      - '!CLAUDE.md'
-      - 'docs/**'
-      - 'specs/**'
-      - 'LICENSE'
-      - '.gitignore'
-      - '.claudeignore'
-      - '.claude/**'
-      - 'benchmarks/**'
-      - '**.png'
-      - '**.jpg'
-      - '**.gif'
-      - '**.svg'
   pull_request:
-    paths-ignore:
-      - '*.md'
-      - '!CLAUDE.md'
-      - 'docs/**'
-      - 'specs/**'
-      - 'LICENSE'
-      - '.gitignore'
-      - '.claudeignore'
-      - '.claude/**'
-      - 'benchmarks/**'
-      - '**.png'
-      - '**.jpg'
-      - '**.gif'
-      - '**.svg'
   workflow_call:
 
 concurrency:
@@ -41,14 +13,38 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: read   # required by dorny/paths-filter on pull_request events
 
 jobs:
 
+  # Path-detection gate. Workflow always triggers; heavy jobs gate on the
+  # `code` output below. Replaces trigger-level `paths-ignore`, which deadlocks
+  # with Repository Rulesets (no synthetic success for required checks).
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Detect code changes
+        id: filter
+        uses: dorny/paths-filter@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v3
+        with:
+          filters: |
+            code:
+              - '!(**.md|docs/**|specs/**|LICENSE|.gitignore|.claudeignore|.claude/**|benchmarks/**|**.png|**.jpg|**.gif|**.svg)'
+              - 'CLAUDE.md'
+
   static-check:
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0  # needed for gitleaks / git history scans
 
@@ -57,7 +53,8 @@ jobs:
       # mise-managed installs. Replaces actions/setup-go and the parallel
       # `~/.local/bin` + `~/go/bin` caches that were needed when tools were
       # installed piecemeal by the Makefile.
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      - name: Set up toolchain (mise)
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
           cache: true
@@ -76,13 +73,16 @@ jobs:
         run: make static-check
 
   build:
-    needs: [static-check]
+    needs: [changes, static-check]
+    if: needs.changes.outputs.code == 'true'
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      - name: Set up toolchain (mise)
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
           cache: true
@@ -109,13 +109,16 @@ jobs:
           retention-days: 1
 
   test:
-    needs: [static-check]
+    needs: [changes, static-check]
+    if: needs.changes.outputs.code == 'true'
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      - name: Set up toolchain (mise)
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
           cache: true
@@ -145,13 +148,16 @@ jobs:
           retention-days: 7
 
   integration-test:
-    needs: [static-check]
+    needs: [changes, static-check]
+    if: needs.changes.outputs.code == 'true'
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      - name: Set up toolchain (mise)
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
           cache: true
@@ -176,17 +182,20 @@ jobs:
   # + Postman collection for flight-path (Go REST API); swap for Playwright /
   # Cypress / Failsafe / pytest+requests as appropriate per project.
   e2e:
-    needs: [build, test]
+    needs: [changes, build, test]
+    if: needs.changes.outputs.code == 'true'
     timeout-minutes: 15
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       # mise-action installs BOTH go (from .mise.toml) and node (from
       # .mise.toml, which mirrors .nvmrc). Replaces the parallel setup-go +
       # setup-node pair.
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      - name: Set up toolchain (mise)
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
           cache: true
@@ -217,7 +226,7 @@ jobs:
       # Fallback: rebuild if artifact download failed (e.g., under act,
       # cross-job artifact download is unreliable; continue-on-error + this
       # fallback make the job work in both GHA and act environments).
-      - name: Build
+      - name: Build (fallback)
         if: steps.download-binary.outcome == 'failure'
         run: make build
 
@@ -231,12 +240,13 @@ jobs:
         run: make e2e-quick
 
   dast:
-    if: ${{ vars.ACT != 'true' }}
-    needs: [build, test]
+    if: ${{ vars.ACT != 'true' && needs.changes.outputs.code == 'true' }}
+    needs: [changes, build, test]
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Download build artifact
         id: download-binary
@@ -248,21 +258,23 @@ jobs:
       # Fallback path: install toolchain via mise and rebuild if artifact
       # download failed (pulls Go from .mise.toml — same source of truth as
       # the build job).
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      - name: Set up toolchain (mise, fallback)
         if: steps.download-binary.outcome == 'failure'
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
           cache: true
 
-      - name: Build
+      - name: Build (fallback)
         if: steps.download-binary.outcome == 'failure'
         run: make build
 
+      - name: Make binary executable
+        run: chmod +x server
+
       - name: Compute ZAP cache key
         id: zap-week
-        run: |
-          chmod +x server
-          echo "week=$(date -u +%Y-W%V)" >> "$GITHUB_OUTPUT"
+        run: echo "week=$(date -u +%Y-W%V)" >> "$GITHUB_OUTPUT"
 
       - name: Cache ZAP Docker image
         id: zap-cache
@@ -297,21 +309,25 @@ jobs:
         run: pkill -f './server' 2>/dev/null || true
 
   # Release: binaries via GoReleaser. Tag-gated — only runs on v*.*.* pushes.
-  # Runs in parallel with the `docker` job (both publish from the same commit);
-  # ci-pass waits for both before going green.
+  # Anchor of the multi-artifact release: creates the GitHub Release object
+  # that downstream artifacts (the Docker image) attach to. `docker` is
+  # serialized after this via `needs:` so a tag either produces both
+  # artifacts or none.
   goreleaser:
     if: startsWith(github.ref, 'refs/tags/')
-    needs: [static-check, build, test, integration-test, e2e, dast]
+    needs: [changes, static-check, build, test, integration-test, e2e, dast]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: write    # create GitHub Release with binaries, archives, checksums, changelog
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0   # goreleaser needs full history for changelog
 
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      - name: Set up toolchain (mise)
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
           cache: true
@@ -333,8 +349,20 @@ jobs:
   # commit. Dockerfile regressions, multi-arch build issues, and cosign
   # installer breakage are caught on the commit that introduced them, not on
   # release day.
+  #
+  # `goreleaser` is in `needs:` for serialization on tag pushes — the GitHub
+  # Release object must exist before the image is published, so a tag either
+  # produces both artifacts or none. On non-tag pushes goreleaser is skipped
+  # (treated as success by `needs:`), so docker still runs every push.
   docker:
-    needs: [static-check, build, test]
+    needs: [changes, static-check, build, test, goreleaser]
+    if: |
+      always() &&
+      needs.changes.outputs.code == 'true' &&
+      needs.static-check.result == 'success' &&
+      needs.build.result == 'success' &&
+      needs.test.result == 'success' &&
+      (needs.goreleaser.result == 'success' || needs.goreleaser.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -342,11 +370,14 @@ jobs:
       packages: write    # exercised only by the tag-gated push step
       id-token: write    # exercised only by the tag-gated cosign sign step
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
-      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       # Weekly cache-bust for the apk upgrade layer so the image picks up new
       # Alpine security patches even when the Dockerfile is unchanged.
@@ -466,14 +497,16 @@ jobs:
             cosign sign --yes "${tag}@${DIGEST}"
           done <<< "${TAGS}"
 
-  # Single branch-protection gate. Includes tag-gated goreleaser + docker so
-  # that on tag pushes ci-pass only goes green once the full release publish
-  # has verified green. On non-tag pushes those jobs are `skipped`, which
+  # Single branch-protection gate. Includes the `changes` detector + every
+  # downstream job (incl. tag-gated goreleaser + docker) so on tag pushes
+  # ci-pass only goes green once the full release publish has verified clean.
+  # Skipped jobs (changes.code=false on doc-only PRs, goreleaser on non-tag
+  # pushes, dast under act) are `result: 'skipped'`, which
   # `contains(needs.*.result, 'failure')` treats as non-failure — ci-pass
-  # still passes correctly.
+  # passes correctly.
   ci-pass:
     if: always()
-    needs: [static-check, build, test, integration-test, e2e, dast, docker, goreleaser]
+    needs: [changes, static-check, build, test, integration-test, e2e, dast, goreleaser, docker]
     timeout-minutes: 2
     runs-on: ubuntu-latest
     steps:
@@ -483,3 +516,8 @@ jobs:
             echo "One or more jobs failed"
             exit 1
           fi
+          if [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more jobs were cancelled"
+            exit 1
+          fi
+          echo "All required jobs passed or were skipped."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,17 @@ jobs:
   # Path-detection gate. Workflow always triggers; heavy jobs gate on the
   # `code` output below. Replaces trigger-level `paths-ignore`, which deadlocks
   # with Repository Rulesets (no synthetic success for required checks).
+  #
+  # Tag pushes always force `code=true` so the full CI pipeline (incl. e2e,
+  # docker, goreleaser) runs on every release tag — preserves the original
+  # "tags are unaffected by paths-ignore" guarantee. Without this, a tag
+  # pointing at a doc-only commit would skip every gated job and goreleaser
+  # would publish a release with zero tests run.
   changes:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     outputs:
-      code: ${{ steps.filter.outputs.code }}
+      code: ${{ steps.decide.outputs.code }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -36,6 +42,16 @@ jobs:
             code:
               - '!(**.md|docs/**|specs/**|LICENSE|.gitignore|.claudeignore|.claude/**|benchmarks/**|**.png|**.jpg|**.gif|**.svg)'
               - 'CLAUDE.md'
+      - name: Decide code output (force true on tag pushes)
+        id: decide
+        env:
+          FILTER_CODE: ${{ steps.filter.outputs.code }}
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "code=${FILTER_CODE}" >> "$GITHUB_OUTPUT"
+          fi
 
   static-check:
     needs: [changes]
@@ -240,7 +256,7 @@ jobs:
         run: make e2e-quick
 
   dast:
-    if: ${{ vars.ACT != 'true' && needs.changes.outputs.code == 'true' }}
+    if: vars.ACT != 'true' && needs.changes.outputs.code == 'true'
     needs: [changes, build, test]
     timeout-minutes: 15
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,25 +257,26 @@ All quality/security tools below are installed in one pass by
 
 ## CI/CD
 
-GitHub Actions CI workflow runs on push to `main`, tags `v*`, and pull requests. Non-critical files are excluded via `paths-ignore` (docs, images, benchmarks, `.claude/**`, metadata) — `CLAUDE.md` is re-included via `!CLAUDE.md` negation. Tags are unaffected by `paths-ignore`.
+GitHub Actions CI workflow runs on push to `main`, tags `v*`, and pull requests. The workflow always triggers; a `changes` detector job (`dorny/paths-filter`) gates every heavy job on whether the push touches code (negated glob over `**.md`, `docs/**`, `specs/**`, `LICENSE`, `.gitignore`, `.claudeignore`, `.claude/**`, `benchmarks/**`, image assets — with `CLAUDE.md` re-included as project config). Doc-only PRs only run `changes` (~10s) and `ci-pass` (which treats skipped jobs as success). Avoids the trigger-level `paths-ignore` deadlock with Repository Rulesets — the workflow always reports `ci-pass`, satisfying required-check gates.
 
 Claude Code workflow (`claude.yml`) provides interactive mode (responds to `@claude` mentions, restricted to `OWNER`/`MEMBER`/`COLLABORATOR` author associations) and automated PR review on every non-draft PR. Claude CI Fix workflow (`claude-ci-fix.yml`) auto-triggers on CI failures via `workflow_run` (same-repo branches only) and uses a dual anti-recursion guard (bot-author check + `claude-fix-attempted` label) plus a 12K total input cap on CI logs to prevent prompt-injection context stuffing.
 
-All jobs live in `.github/workflows/ci.yml` (single-file layout matching the `/ci-workflow` skill template). Tag-gated jobs (`goreleaser`, `docker`) are siblings of the normal CI jobs and run only on `v*.*.*` pushes — they are `skipped` on branch/PR pushes.
+All jobs live in `.github/workflows/ci.yml` (single-file layout matching the `/ci-workflow` skill template). The release-side `goreleaser` (tag-only) and `docker` (every push, push/sign tag-gated) are serialized via `needs:` so a tag either produces both the GitHub Release object AND the GHCR image, or neither — no half-released tags.
 
 | Job | Triggers | Steps |
 |-----|----------|-------|
-| **static-check** | all | `make static-check` (lint-ci + lint + sec + vulncheck + secrets + trivy-fs + mermaid-lint + release-check) |
-| **build** | all | Build binary, upload `server-binary` artifact |
-| **test** | all | Coverage threshold check (80%+), fuzz tests, upload coverage artifact |
-| **integration-test** | all | `make integration-test` — full HTTP stack (middleware, CORS branches, error envelope, preflight) via httptest |
-| **e2e** | all | Download binary (fallback rebuild), run server, Newman/Postman E2E tests. Canonical name for the mandatory end-to-end test job — wraps `make e2e`. Runs on every push AND under `act` via `make ci-run` (no `vars.ACT` guard). |
-| **dast** | all (skipped in act) | Download binary (fallback rebuild), run server, OWASP ZAP API security scan |
-| **docker** | all (push/sign steps tag-gated) | Gates 1–3 run every push: single-arch build + Trivy image scan (CRITICAL/HIGH blocking) + `make image-smoke-test`. Gate 4 multi-arch build runs every push (`push: ${{ startsWith(github.ref, 'refs/tags/') }}`). On `v*.*.*` tags: additionally logs in to GHCR, pushes with clean image index (Pattern A: `provenance: false` + `sbom: false`), installs cosign, and signs by digest. Catches Dockerfile + multi-arch regressions on the commit that introduced them, not on release day. |
-| **goreleaser** | tag push only | GoReleaser builds multi-platform binaries, archives, checksums, changelog, and GitHub Release |
-| **ci-pass** | always | Aggregator gate (`if: always()`, `needs:` all upstream including docker + goreleaser) — single required check for branch protection. On non-tag pushes, goreleaser is `skipped` (not `failure`) and docker runs normally to validate the full pipeline. On tag pushes, ci-pass waits for everything and only goes green after the full release verifies clean. |
+| **changes** | all | `dorny/paths-filter` — emits `code` output; downstream jobs gate on `needs.changes.outputs.code == 'true'` |
+| **static-check** | code changes | `make static-check` (lint-ci + lint + sec + vulncheck + secrets + trivy-fs + mermaid-lint + release-check) |
+| **build** | code changes | Build binary, upload `server-binary` artifact |
+| **test** | code changes | Coverage threshold check (80%+), fuzz tests, upload coverage artifact |
+| **integration-test** | code changes | `make integration-test` — full HTTP stack (middleware, CORS branches, error envelope, preflight) via httptest |
+| **e2e** | code changes | Download binary (fallback rebuild), run server, Newman/Postman E2E tests. Canonical name for the mandatory end-to-end test job — wraps `make e2e`. Runs on every push AND under `act` via `make ci-run` (no `vars.ACT` guard). |
+| **dast** | code changes (skipped in act) | Download binary (fallback rebuild), run server, OWASP ZAP API security scan |
+| **goreleaser** | tag push only | GoReleaser builds multi-platform binaries, archives, checksums, changelog, and GitHub Release. Anchor of the multi-artifact release — `docker` is serialized after this so a tag either produces both artifacts or none. |
+| **docker** | code changes; serialized after goreleaser on tag push | Gates 1–3 run every push: single-arch build + Trivy image scan (CRITICAL/HIGH blocking) + `make image-smoke-test`. Gate 4 multi-arch build runs every push (`push: ${{ startsWith(github.ref, 'refs/tags/') }}`). On `v*.*.*` tags: additionally logs in to GHCR, pushes with clean image index (Pattern A: `provenance: false` + `sbom: false`), installs cosign, and signs by digest. Catches Dockerfile + multi-arch regressions on the commit that introduced them, not on release day. |
+| **ci-pass** | always | Aggregator gate (`if: always()`, `needs:` all upstream including changes + docker + goreleaser) — single required check for branch protection. Skipped jobs (changes.code=false on doc-only PRs, goreleaser on non-tag pushes, dast under act) are `result: 'skipped'`, which `contains(needs.*.result, 'failure')` treats as non-failure — ci-pass passes correctly. |
 
-The `dast` job is skipped when running locally with `act` (`vars.ACT == 'true'`) because OWASP ZAP needs Docker-in-Docker. The `e2e` and `docker` jobs run cleanly under act: `e2e` rebuilds the binary locally when cross-job artifact download fails, and `docker` exercises all gates (the tag-gated push/sign steps are skipped on non-tag pushes).
+The `dast` job is skipped when running locally with `act` (`vars.ACT == 'true'`) because OWASP ZAP needs Docker-in-Docker. The `e2e` and `docker` jobs run cleanly under act: `e2e` rebuilds the binary locally when cross-job artifact download fails, and `docker` exercises all gates (the tag-gated push/sign steps are skipped on non-tag pushes). The `make ci-run` target generates a synthetic event payload via `--eventpath` so `dorny/paths-filter` can resolve `repository.default_branch` (which act omits by default).
 
 There is no separate `release.yml` — the tag-push release pipeline lives inside `ci.yml` as tag-gated sibling jobs, so `ci-pass` aggregates both CI and release phases into a single green check.
 

--- a/Makefile
+++ b/Makefile
@@ -313,14 +313,23 @@ ci: deps format static-check test integration-test coverage-check build fuzz dep
 	@echo "Local CI pipeline passed."
 
 #ci-run: @ Run GitHub Actions workflow locally using act
+# Synthetic push-event payload (--eventpath) gives dorny/paths-filter the
+# repository.default_branch field act omits by default — without it, the
+# `changes` detector job errors and every downstream gated job is blocked.
 ci-run: deps
 	@docker container prune -f 2>/dev/null || true
-	@if [ -f ~/.secrets ]; then . ~/.secrets; fi; \
+	@EVENT=$$(mktemp /tmp/act-push-event.XXXXXX.json); \
+	printf '{"repository":{"default_branch":"main"},"ref":"refs/heads/main","before":"0000000000000000000000000000000000000000","after":"0000000000000000000000000000000000000000"}' > $$EVENT; \
+	if [ -f ~/.secrets ]; then . ~/.secrets; fi; \
 	act push -W .github/workflows/ci.yml \
+		--eventpath $$EVENT \
 		--container-architecture linux/amd64 \
 		--artifact-server-path /tmp/act-artifacts \
 		--var ACT=true \
-		$${GITHUB_TOKEN:+-s GITHUB_TOKEN=$$GITHUB_TOKEN}
+		$${GITHUB_TOKEN:+-s GITHUB_TOKEN=$$GITHUB_TOKEN}; \
+	RC=$$?; \
+	rm -f $$EVENT; \
+	exit $$RC
 
 #check: @ Run pre-commit checklist (alias for ci)
 check: ci

--- a/Makefile
+++ b/Makefile
@@ -316,6 +316,10 @@ ci: deps format static-check test integration-test coverage-check build fuzz dep
 # Synthetic push-event payload (--eventpath) gives dorny/paths-filter the
 # repository.default_branch field act omits by default — without it, the
 # `changes` detector job errors and every downstream gated job is blocked.
+# The all-zero before/after SHAs make dorny treat the push as the initial
+# commit and report every file as changed, so `code=true` and every job
+# runs — desired behavior for local CI (opposite of the doc-only-skip
+# behavior on GitHub).
 ci-run: deps
 	@docker container prune -f 2>/dev/null || true
 	@EVENT=$$(mktemp /tmp/act-push-event.XXXXXX.json); \

--- a/README.md
+++ b/README.md
@@ -253,19 +253,20 @@ Run `make help` to see all available targets.
 
 ## CI/CD
 
-GitHub Actions runs on every push to `main`, tags `v*`, and pull requests. All jobs live in a single workflow file (`.github/workflows/ci.yml`). Tag-gated jobs (`goreleaser`, `docker`) are siblings of the other jobs — they run only on `v*.*.*` pushes and are `skipped` on everything else.
+GitHub Actions runs on every push to `main`, tags `v*`, and pull requests. All jobs live in a single workflow file (`.github/workflows/ci.yml`). The workflow always triggers; a `changes` detector job (`dorny/paths-filter`) gates every heavy job on whether the push touches code — doc-only PRs only run `changes` (~10s) and `ci-pass`. The release-side `goreleaser` (tag-only) and `docker` (every push, push/sign tag-gated) are serialized via `needs:` so a tag either produces both the GitHub Release AND the GHCR image, or neither.
 
 | Job | Triggers | Steps |
 |-----|----------|-------|
-| **static-check** | push, PR, tags | `make static-check` (lint-ci + lint + sec + vulncheck + secrets + trivy-fs + mermaid-lint + release-check) |
-| **build** | after static-check | Build binary, upload artifact |
-| **test** | after static-check | Coverage threshold check (80%+), fuzz tests |
-| **integration-test** | after static-check | Full HTTP stack + middleware tests (`//go:build integration`) |
-| **e2e** | after build + test | Download binary (or rebuild fallback), run server, Newman/Postman E2E tests. Runs on every push AND under `act` (no `vars.ACT` guard) — the fallback path rebuilds the binary when cross-job artifact download fails. |
-| **dast** | after build + test | Run server, OWASP ZAP API security scan |
-| **docker** | after static-check + build + test (every push) | Single-arch build + Trivy image scan (CRITICAL/HIGH blocking) + `make image-smoke-test` + multi-arch build. On `v*.*.*` tag pushes, additionally logs in to GHCR, pushes multi-arch (clean image index, Pattern A), and cosign-signs by digest. On non-tag pushes the login/push/sign steps are skipped — the job still runs end-to-end to catch Dockerfile and multi-arch build regressions on the commit that introduced them, not on release day. |
-| **goreleaser** | tag push only, after all upstream | GoReleaser build, GitHub release (binaries, archives, checksums, changelog) |
-| **ci-pass** | `if: always()`, needs all | Single branch-protection gate that fails if any upstream job failed. On non-tag pushes, `goreleaser` is `skipped` (not `failure`) and `docker` runs normally, so ci-pass still passes correctly. On tag pushes, ci-pass waits for all jobs and only goes green after the full release has verified clean. |
+| **changes** | push, PR, tags | `dorny/paths-filter` — emits `code` output. Filter: `!(**.md|docs/**|specs/**|LICENSE|.gitignore|.claudeignore|.claude/**|benchmarks/**|**.png|**.jpg|**.gif|**.svg)` plus `CLAUDE.md` re-include. |
+| **static-check** | code changes | `make static-check` (lint-ci + lint + sec + vulncheck + secrets + trivy-fs + mermaid-lint + release-check) |
+| **build** | code changes, after static-check | Build binary, upload artifact |
+| **test** | code changes, after static-check | Coverage threshold check (80%+), fuzz tests |
+| **integration-test** | code changes, after static-check | Full HTTP stack + middleware tests (`//go:build integration`) |
+| **e2e** | code changes, after build + test | Download binary (or rebuild fallback), run server, Newman/Postman E2E tests. Runs on every push AND under `act` (no `vars.ACT` guard) — the fallback path rebuilds the binary when cross-job artifact download fails. |
+| **dast** | code changes, after build + test | Run server, OWASP ZAP API security scan (skipped under `act`) |
+| **goreleaser** | tag push only, after all upstream | GoReleaser build, GitHub release (binaries, archives, checksums, changelog). Anchor of the multi-artifact release — `docker` is serialized after this so a tag either produces both artifacts or none. |
+| **docker** | code changes, after static-check + build + test; serialized after goreleaser on tag push | Single-arch build + Trivy image scan (CRITICAL/HIGH blocking) + `make image-smoke-test` + multi-arch build. On `v*.*.*` tag pushes, additionally logs in to GHCR, pushes multi-arch (clean image index, Pattern A), and cosign-signs by digest. On non-tag pushes the login/push/sign steps are skipped — the job still runs end-to-end to catch Dockerfile and multi-arch build regressions on the commit that introduced them, not on release day. |
+| **ci-pass** | `if: always()`, needs all | Single branch-protection gate that fails if any upstream job failed. Skipped jobs (changes.code=false on doc-only PRs, goreleaser on non-tag pushes, dast under act) are `result: 'skipped'`, treated as non-failure — ci-pass passes correctly. |
 
 ### Required Secrets and Variables
 


### PR DESCRIPTION
## Summary

Address three findings from `/ci-workflow` review:

- **BLOCKING — Path-filter strategy.** Replace trigger-level `paths-ignore` with a `changes` detector job using `dorny/paths-filter` + per-job `if: needs.changes.outputs.code == 'true'`. The previous trigger-level filter deadlocks with Repository Rulesets (no synthetic success for required checks → `ci-pass` never reports → required-check gate never clears, even for admin push). Doc-only PRs now run only `changes` (~10s) and `ci-pass` (skipped jobs treated as success).
- **HIGH — Multi-artifact release serialization.** `goreleaser` (tag-only) and `docker` (every push, push/sign tag-gated) previously ran in parallel on tag pushes. `docker.needs` now includes `goreleaser` so a tag either produces both the GitHub Release object AND the GHCR image, or neither. The explicit `if:` allows `goreleaser` to be `success` OR `skipped` so docker still runs every push when goreleaser is tag-skipped.
- **HIGH — Step `name:` field.** Added explicit `name:` to every `uses:` step (`Checkout`, `Set up toolchain (mise)`, `Set up QEMU`, `Set up Docker Buildx`, `Download build artifact`, etc.) so CI logs read `Run Checkout` instead of `Run actions/checkout@de0fac…` — `gh run view --log` is now greppable.

Also:
- Move stray `chmod +x server` out of `Compute ZAP cache key` into its own step
- `Makefile` `ci-run`: feed `act` a synthetic push-event payload via `--eventpath` so `dorny/paths-filter` can resolve `repository.default_branch` (which act omits by default)
- Update CLAUDE.md and README.md CI/CD sections

## Test plan

- [x] `make static-check` — passed clean (no findings)
- [x] `make ci-run` (act, full GitHub Actions workflow locally) — passed end-to-end (exit 0). `docker` job built single-arch + Trivy scan + smoke test + multi-arch (linux/amd64 + linux/arm64); `ci-pass` printed "All required jobs passed or were skipped"
- [ ] CI passes on this PR (validates the `changes` detector + serialization in the real GitHub Actions environment)
- [ ] Confirm `ci-pass` reports green and the required-check gate clears (validates the Rulesets fix end-to-end)