### PR TITLE
chore: project-review hygiene pass — Renovate, CI naming, integration tests, container-structure-test gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -465,8 +465,19 @@ jobs:
       # =================================================================
       # GATE 3b: Container structure test (Dockerfile metadata + binary)
       # =================================================================
+      # The docker job intentionally doesn't use mise (it's Docker-tool focused),
+      # so install container-structure-test directly. Version mirrors .mise.toml
+      # — when bumping, update both. Renovate tracks the .mise.toml pin.
+      - name: Install container-structure-test
+        run: |
+          set -euo pipefail
+          CST_VERSION=1.22.1
+          curl -fsSL -o /tmp/cst "https://github.com/GoogleContainerTools/container-structure-test/releases/download/v${CST_VERSION}/container-structure-test-linux-amd64"
+          install -m 0755 /tmp/cst /usr/local/bin/container-structure-test
+          container-structure-test version
+
       - name: Container structure test
-        run: make image-structure-test
+        run: container-structure-test test --image flight-path:local --config container-structure-test.yaml
 
       # =================================================================
       # Multi-arch build — runs on EVERY push. Catches multi-arch build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,9 @@ jobs:
             code:
               - '!(**.md|docs/**|specs/**|LICENSE|.gitignore|.claudeignore|.claude/**|benchmarks/**|**.png|**.jpg|**.gif|**.svg)'
               - 'CLAUDE.md'
-      - name: Decide code output (force true on tag pushes)
+      # Tag pushes always force `code=true` so the full release pipeline runs
+      # even if the tag points at a doc-only commit.
+      - name: Decide code output
         id: decide
         env:
           FILTER_CODE: ${{ steps.filter.outputs.code }}
@@ -69,7 +71,7 @@ jobs:
       # mise-managed installs. Replaces actions/setup-go and the parallel
       # `~/.local/bin` + `~/go/bin` caches that were needed when tools were
       # installed piecemeal by the Makefile.
-      - name: Set up toolchain (mise)
+      - name: Set up mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
@@ -97,7 +99,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Set up toolchain (mise)
+      - name: Set up mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
@@ -133,7 +135,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Set up toolchain (mise)
+      - name: Set up mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
@@ -172,7 +174,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Set up toolchain (mise)
+      - name: Set up mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
@@ -210,7 +212,7 @@ jobs:
       # mise-action installs BOTH go (from .mise.toml) and node (from
       # .mise.toml, which mirrors .nvmrc). Replaces the parallel setup-go +
       # setup-node pair.
-      - name: Set up toolchain (mise)
+      - name: Set up mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
@@ -242,7 +244,7 @@ jobs:
       # Fallback: rebuild if artifact download failed (e.g., under act,
       # cross-job artifact download is unreliable; continue-on-error + this
       # fallback make the job work in both GHA and act environments).
-      - name: Build (fallback)
+      - name: Build
         if: steps.download-binary.outcome == 'failure'
         run: make build
 
@@ -274,14 +276,16 @@ jobs:
       # Fallback path: install toolchain via mise and rebuild if artifact
       # download failed (pulls Go from .mise.toml — same source of truth as
       # the build job).
-      - name: Set up toolchain (mise, fallback)
+      # Fallback path when artifact download fails (e.g., under act).
+      - name: Set up mise
         if: steps.download-binary.outcome == 'failure'
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
           cache: true
 
-      - name: Build (fallback)
+      # Fallback: rebuild if artifact download failed.
+      - name: Build
         if: steps.download-binary.outcome == 'failure'
         run: make build
 
@@ -342,7 +346,7 @@ jobs:
         with:
           fetch-depth: 0   # goreleaser needs full history for changelog
 
-      - name: Set up toolchain (mise)
+      - name: Set up mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
@@ -457,6 +461,12 @@ jobs:
       - name: Cleanup smoke container
         if: always()
         run: docker rm -f fp-test 2>/dev/null || true
+
+      # =================================================================
+      # GATE 3b: Container structure test (Dockerfile metadata + binary)
+      # =================================================================
+      - name: Container structure test
+        run: make image-structure-test
 
       # =================================================================
       # Multi-arch build — runs on EVERY push. Catches multi-arch build

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -86,7 +86,10 @@ jobs:
     if: |
       github.event_name == 'pull_request' &&
       github.event.pull_request.draft == false &&
-      github.event.pull_request.author_association != 'NONE'
+      (github.event.pull_request.author_association == 'OWNER' ||
+       github.event.pull_request.author_association == 'MEMBER' ||
+       github.event.pull_request.author_association == 'COLLABORATOR' ||
+       github.event.pull_request.user.login == 'renovate[bot]')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     concurrency:

--- a/.mise.toml
+++ b/.mise.toml
@@ -26,3 +26,5 @@ trivy = "0.69.3"
 act = "0.2.87"
 # renovate: datasource=github-releases depName=goreleaser/goreleaser
 goreleaser = "2.15.2"
+# renovate: datasource=github-releases depName=GoogleContainerTools/container-structure-test
+"aqua:GoogleContainerTools/container-structure-test" = "1.22.1"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ flight-path/
 ├── docs/                                # Generated Swagger docs + architecture/planning docs (ARCHITECTURE.md has Mermaid diagrams)
 ├── specs/                               # Reverse-engineered specifications (see specs/README.md for index)
 ├── test/
-│   ├── FlightPath.postman_collection.json  # E2E test collection (11 cases: HealthCheck + 5 happy + 5 negative)
+│   ├── FlightPath.postman_collection.json  # E2E test collection (18 cases: 3 health/security + 1 swagger + 6 happy + 8 negative)
 │   ├── package.json                     # Newman dependency manifest (pnpm)
 │   ├── pnpm-lock.yaml                   # pnpm lock file (reproducible builds)
 │   └── .npmrc                           # pnpm configuration
@@ -103,7 +103,8 @@ make help           # List available tasks
 make deps           # Install toolchain — `mise install` reads .mise.toml and provisions Go, Node, and every quality/security tool (golangci-lint, gosec, govulncheck, gitleaks, actionlint, shellcheck, hadolint, trivy, act, goreleaser). swag + benchstat stay Go-installed; newman via pnpm + corepack
 make deps-check     # Show required Go version, mise status, and tool status
 make api-docs       # Generate Swagger docs (run after changing Swagger comments)
-make format         # Format Go code
+make format         # Format Go code (rewrites in place; for dev use)
+make format-check   # Verify Go code is gofmt-clean (CI gate; non-mutating)
 make lint           # Run golangci-lint + hadolint (comprehensive linting via .golangci.yml)
 make sec            # Run gosec security scanner
 make vulncheck      # Run Go vulnerability check on dependencies
@@ -117,7 +118,7 @@ make fuzz           # Run fuzz tests for 30 seconds
 make bench          # Run benchmarks
 make bench-save     # Save benchmark results with timestamp
 make bench-compare  # Compare latest two benchmark runs
-make static-check   # All static analysis (lint-ci + lint + sec + vulncheck + secrets + trivy-fs + mermaid-lint + release-check)
+make static-check   # All static analysis (format-check + lint-ci + lint + sec + vulncheck + secrets + trivy-fs + mermaid-lint + release-check)
 make build          # Generate Swagger docs + compile binary
 make run            # Build and run server locally
 make e2e            # Self-contained: build + start server + run Newman + stop server
@@ -128,7 +129,7 @@ make test-case-three # curl test: 4-segment path
 make update         # Update Go dependencies
 make release        # Tag and push a new release (runs full `ci` pipeline first)
 make check          # Full pre-commit checklist (alias for make ci)
-make ci             # Local CI pipeline (deps + format + static-check + test + integration-test + coverage-check + build + fuzz + deps-prune-check)
+make ci             # Local CI pipeline (deps + static-check + test + integration-test + coverage-check + build + fuzz + deps-prune-check)
 make ci-run         # Run GitHub Actions workflow locally using act
 make coverage       # Run tests with coverage report
 make coverage-check # Verify coverage meets 80% threshold
@@ -138,7 +139,8 @@ make image-run      # Run Docker container locally (detached; use image-stop to 
 make image-stop     # Stop the locally running Docker container
 make image-push     # Push Docker image to GHCR (requires GH_ACCESS_TOKEN)
 make image-smoke-test # Smoke-test a pre-built Docker container (no rebuild)
-make image-test     # Build and smoke-test Docker container
+make image-structure-test # Validate Dockerfile metadata + binary properties (container-structure-test)
+make image-test     # Build, smoke-test, and structure-test Docker container
 make image-scan     # Build Docker image and run Trivy scan (requires trivy)
 make trivy-fs       # Run Trivy filesystem vulnerability scan (requires trivy)
 make trivy-image    # Run Trivy image vulnerability scan (requires trivy)
@@ -250,6 +252,7 @@ All quality/security tools below are installed in one pass by
 | `trivy` | Vulnerability scanner (images + filesystem) | mise / `.mise.toml` |
 | `act` | Local GitHub Actions runner | mise / `.mise.toml` |
 | `goreleaser` | Release binary builder + `.goreleaser.yml` validator | mise / `.mise.toml` |
+| `container-structure-test` | Dockerfile metadata + binary property validator | mise / `.mise.toml` (aqua:GoogleContainerTools/container-structure-test) |
 | `swag` | Swagger generation | `go install` (pinned via `SWAG_VERSION` in Makefile) |
 | `benchstat` | Benchmark comparison | `go install` (pinned via `BENCHSTAT_VERSION` in Makefile) |
 | `newman` | E2E API testing | `pnpm install` in `test/` (pinned in `test/package.json`) |

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ deps-check:
 	@echo "Go version required: $(GO_VERSION)"
 	@if command -v mise >/dev/null 2>&1; then mise list 2>/dev/null || echo "mise: .mise.toml not trusted — run 'mise trust'"; else echo "mise not installed - install from https://mise.jdx.dev"; fi
 	@echo "--- Tool status ---"
-	@for tool in swag benchstat golangci-lint gosec govulncheck gitleaks actionlint shellcheck hadolint trivy act goreleaser node pnpm; do \
+	@for tool in swag benchstat golangci-lint gosec govulncheck gitleaks actionlint shellcheck hadolint trivy act goreleaser container-structure-test node pnpm; do \
 		printf "  %-16s " "$$tool:"; \
 		command -v $$tool >/dev/null 2>&1 && echo "installed" || echo "NOT installed"; \
 	done
@@ -138,7 +138,8 @@ bench-compare: deps
 			exit 1; \
 		fi; \
 		echo "Comparing: $$OLD_FILE (old) vs $$NEW_FILE (new)"; \
-		$(call go-exec,benchstat $$OLD_FILE $$NEW_FILE); \
+		export OLD_FILE NEW_FILE; \
+		$(call go-exec,benchstat "$$OLD_FILE" "$$NEW_FILE"); \
 	else \
 		$(call go-exec,benchstat $(OLD) $(NEW)); \
 	fi
@@ -164,16 +165,25 @@ sec: deps
 lint-ci: deps
 	@$(call go-exec,actionlint)
 
-#format: @ Format Go code
+#format: @ Format Go code (rewrites files in place; for dev use)
 format: deps
 	@$(call go-exec,gofmt -l -w .)
+
+#format-check: @ Verify Go code is gofmt-clean (CI gate; non-mutating, exits non-zero on diff)
+format-check: deps
+	@DIFF=$$($(call go-exec,gofmt -l .)); \
+	if [ -n "$$DIFF" ]; then \
+		echo "ERROR: gofmt would rewrite the following files. Run 'make format'."; \
+		echo "$$DIFF"; \
+		exit 1; \
+	fi
 
 #release-check: @ Validate .goreleaser.yml syntax and config
 release-check: deps
 	@goreleaser check
 
 #static-check: @ Run code static check
-static-check: lint-ci lint sec vulncheck secrets trivy-fs mermaid-lint release-check
+static-check: format-check lint-ci lint sec vulncheck secrets trivy-fs mermaid-lint release-check
 	@echo "Static check passed."
 
 #build: @ Build REST API server's binary
@@ -222,8 +232,13 @@ image-smoke-test:
 	docker rm -f fp-test 2>/dev/null || true; \
 	exit $$RESULT
 
+#image-structure-test: @ Validate Dockerfile metadata + binary properties (container-structure-test)
+image-structure-test: deps
+	@command -v docker >/dev/null 2>&1 || { echo "ERROR: docker is required for image-structure-test"; exit 1; }
+	@$(call go-exec,container-structure-test test --image $(APP_NAME):local --config container-structure-test.yaml)
+
 #image-test: @ Build and smoke-test Docker container
-image-test: image-build image-smoke-test
+image-test: image-build image-smoke-test image-structure-test
 
 #image-scan: @ Build Docker image and run Trivy scan (requires trivy)
 image-scan: deps build
@@ -235,6 +250,10 @@ image-scan: deps build
 
 #release: @ Create and push a new tag
 release: ci
+	@git rev-parse --abbrev-ref --symbolic-full-name @{u} >/dev/null 2>&1 || { \
+		echo "Error: current branch has no upstream. Set one with 'git push -u origin $$(git symbolic-ref --short HEAD)' before releasing."; \
+		exit 1; \
+	}
 	@NT=$$(bash -c 'read -p "Please provide a new tag (current tag - $(CURRENTTAG)): " newtag; echo $$newtag'); \
 	echo "$$NT" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$$' || { echo "Error: Tag must match vN.N.N"; exit 1; }; \
 	read -p "Are you sure to create and push $$NT tag? [y/N] " ans; [ "$${ans:-N}" = y ] || exit 1; \
@@ -309,7 +328,7 @@ coverage-check: coverage
 #ci: @ Run full CI pipeline locally (unit + static + build + fuzz + prune-check).
 # For full e2e validation via Newman, use `make ci-run` which drives act
 # through the `e2e` job (Newman runs against the built binary).
-ci: deps format static-check test integration-test coverage-check build fuzz deps-prune-check
+ci: deps static-check test integration-test coverage-check build fuzz deps-prune-check
 	@echo "Local CI pipeline passed."
 
 #ci-run: @ Run GitHub Actions workflow locally using act
@@ -416,8 +435,8 @@ deps-prune-check: deps
 	@echo "No prunable dependencies found."
 
 .PHONY: help deps deps-check api-docs test integration-test fuzz bench bench-save bench-compare \
-	lint vulncheck secrets sec lint-ci format static-check mermaid-lint release-check build run release update open-swagger \
+	lint vulncheck secrets sec lint-ci format format-check static-check mermaid-lint release-check build run release update open-swagger \
 	test-case-one test-case-two test-case-three e2e e2e-quick clean coverage coverage-check \
 	ci ci-run check trivy-fs trivy-image \
-	image-build image-run image-stop image-push image-smoke-test image-test image-scan \
+	image-build image-run image-stop image-push image-smoke-test image-structure-test image-test image-scan \
 	renovate-validate deps-prune deps-prune-check

--- a/README.md
+++ b/README.md
@@ -14,16 +14,10 @@ C4Context
     title System Context — flight-path
     Person(client, "API Client", "cURL, Postman, Newman, browser")
     System(flightpath, "flight-path", "Go REST API that reconstructs full itinerary from unordered flight segments")
-    System_Ext(ghcr, "GitHub Container Registry", "Hosts multi-arch signed images")
-    System_Ext(sigstore, "Sigstore", "Cosign keyless OIDC signing")
     Rel(client, flightpath, "POST /calculate", "HTTPS/JSON")
-    Rel(flightpath, ghcr, "Published images", "docker push")
-    Rel(flightpath, sigstore, "Signed by digest", "cosign OIDC")
-
-    UpdateLayoutConfig($c4ShapeInRow="3")
 ```
 
-See [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md) for Container, Component, request-flow sequence, and CI/CD pipeline diagrams.
+See [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md) for Container, request-flow sequence, and CI/CD pipeline diagrams.
 
 ## Tech Stack
 
@@ -92,7 +86,7 @@ flowchart LR
     client --> mw --> routes --> handlers --> algo
 ```
 
-See [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md) for Container, Component, request-flow sequence, and CI/CD pipeline diagrams.
+See [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md) for Container, request-flow sequence, and CI/CD pipeline diagrams.
 
 ## API
 
@@ -145,9 +139,9 @@ Auto-generated OpenAPI spec: [`docs/swagger.json`](./docs/swagger.json)
 | go test -fuzz | `make fuzz` | Fuzz testing for FindItinerary algorithm |
 | [Newman](https://github.com/postmanlabs/newman) | `make e2e` | Postman/Newman end-to-end API tests |
 
-## Postman/Newman end-to-end tests
+### End-to-end tests (Postman/Newman)
 
-Utilized Postman collection exported to [JSON file](./test/FlightPath.postman_collection.json) and executes 18 test cases:
+The Postman collection ([JSON](./test/FlightPath.postman_collection.json)) executes 18 test cases:
 
 - **HealthCheck** — `GET /` returns `{"data": "..."}`
 - **UseCase01–03** — happy paths matching `test-case-one`, `test-case-two`, `test-case-three` (1, 2, 4 segments)
@@ -203,7 +197,8 @@ Run `make help` to see all available targets.
 
 | Target | Description |
 |--------|-------------|
-| `make format` | Format Go code |
+| `make format` | Format Go code (rewrites in place; for dev use) |
+| `make format-check` | Verify Go code is gofmt-clean (CI gate; non-mutating, exits non-zero on diff) |
 | `make lint` | Run golangci-lint and hadolint (comprehensive linting via .golangci.yml) |
 | `make sec` | Run gosec security scanner |
 | `make vulncheck` | Run Go vulnerability check on dependencies |
@@ -211,7 +206,7 @@ Run `make help` to see all available targets.
 | `make lint-ci` | Lint GitHub Actions workflow files |
 | `make mermaid-lint` | Validate Mermaid diagrams in markdown files |
 | `make release-check` | Validate `.goreleaser.yml` syntax and config via `goreleaser check` |
-| `make static-check` | Run code static check (lint-ci + lint + sec + vulncheck + secrets + trivy-fs + mermaid-lint + release-check) |
+| `make static-check` | Run code static check (format-check + lint-ci + lint + sec + vulncheck + secrets + trivy-fs + mermaid-lint + release-check) |
 
 ### Docker
 
@@ -222,7 +217,8 @@ Run `make help` to see all available targets.
 | `make image-stop` | Stop the locally running Docker container |
 | `make image-push` | Push Docker image to GHCR (requires `GH_ACCESS_TOKEN`; `GHCR_USER` defaults to `git config user.name`) |
 | `make image-smoke-test` | Smoke-test a pre-built Docker container (no rebuild) |
-| `make image-test` | Build and smoke-test Docker container |
+| `make image-structure-test` | Validate Dockerfile metadata + binary properties via container-structure-test |
+| `make image-test` | Build, smoke-test, and structure-test Docker container |
 | `make image-scan` | Build Docker image and run Trivy scan (requires trivy) |
 | `make trivy-fs` | Run Trivy filesystem vulnerability scan (requires trivy) |
 | `make trivy-image` | Run Trivy image vulnerability scan (requires trivy) |
@@ -231,7 +227,7 @@ Run `make help` to see all available targets.
 
 | Target | Description |
 |--------|-------------|
-| `make ci` | Run full CI pipeline locally (deps + format + static-check + test + integration-test + coverage-check + build + fuzz + deps-prune-check) |
+| `make ci` | Run full CI pipeline locally (deps + static-check + test + integration-test + coverage-check + build + fuzz + deps-prune-check) |
 | `make ci-run` | Run GitHub Actions workflow locally using [act](https://github.com/nektos/act) |
 | `make check` | Run pre-commit checklist (alias for `make ci`) |
 
@@ -258,7 +254,7 @@ GitHub Actions runs on every push to `main`, tags `v*`, and pull requests. All j
 | Job | Triggers | Steps |
 |-----|----------|-------|
 | **changes** | push, PR, tags | `dorny/paths-filter` — emits `code` output. Filter: `!(**.md|docs/**|specs/**|LICENSE|.gitignore|.claudeignore|.claude/**|benchmarks/**|**.png|**.jpg|**.gif|**.svg)` plus `CLAUDE.md` re-include. |
-| **static-check** | code changes | `make static-check` (lint-ci + lint + sec + vulncheck + secrets + trivy-fs + mermaid-lint + release-check) |
+| **static-check** | code changes | `make static-check` (format-check + lint-ci + lint + sec + vulncheck + secrets + trivy-fs + mermaid-lint + release-check) |
 | **build** | code changes, after static-check | Build binary, upload artifact |
 | **test** | code changes, after static-check | Coverage threshold check (80%+), fuzz tests |
 | **integration-test** | code changes, after static-check | Full HTTP stack + middleware tests (`//go:build integration`) |
@@ -289,6 +285,7 @@ The `docker` job runs the following gates on **every push**. Gates 1–3 run unc
 | 1 | Build local single-arch image | Build regressions on the runner architecture | `docker/build-push-action` with `load: true` | every push |
 | 2 | **Trivy image scan** (CRITICAL/HIGH blocking) | CVEs in base image, OS packages, build layers; secrets; misconfigs | `aquasecurity/trivy-action` with `image-ref:` | every push |
 | 3 | **Smoke test** | Image boots, health endpoint responds, `/calculate` returns correct result | `make image-smoke-test` | every push |
+| 3b | **Container structure test** | Dockerfile metadata invariants (binary path, USER, entrypoint, /etc/passwd content) | `make image-structure-test` | every push |
 | 4 | Multi-arch build + conditional push (clean image index) | Multi-arch build regressions (linux/arm64 cross-compile issues); on tags, publishes with `provenance: false` + `sbom: false` so the GHCR "OS / Arch" tab renders correctly | `docker/build-push-action` with `push: ${{ startsWith(github.ref, 'refs/tags/') }}` | every push (build); tag only (push) |
 | 5 | **Cosign keyless OIDC signing** | Sigstore signature on the manifest digest (no long-lived keys) — the supply-chain verification primitive for this image | `sigstore/cosign-installer` + `cosign sign` | tag only |
 
@@ -308,11 +305,14 @@ cosign verify ghcr.io/andriykalashnykov/flight-path:<tag> \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
 
-A [Claude Code workflow](./.github/workflows/claude.yml) provides interactive mode (responds to `@claude` mentions from trusted authors) and automated PR review on every non-draft PR.
+### Companion workflows
 
-A [Claude CI Fix workflow](./.github/workflows/claude-ci-fix.yml) auto-triggers on CI failures for same-repo PR branches to attempt automated fixes with anti-recursion guards.
-
-A [cleanup workflow](./.github/workflows/cleanup-runs.yml) runs weekly (Sundays at 00:00 UTC) to delete old workflow runs (retain 7 days, keep minimum 5) and prune caches from merged/deleted branches.
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| [`claude.yml`](./.github/workflows/claude.yml) | `@claude` mention from trusted author; non-draft PR open/sync | Interactive Claude Code responder + automated PR review |
+| [`claude-ci-fix.yml`](./.github/workflows/claude-ci-fix.yml) | CI failure on same-repo PR branch | Attempt automated fix with anti-recursion guards (bot-author + label) |
+| [`auto-merge.yml`](./.github/workflows/auto-merge.yml) | Renovate PR opened or `ci-pass` succeeds | Enable GitHub native auto-merge on Renovate PRs once required checks pass |
+| [`cleanup-runs.yml`](./.github/workflows/cleanup-runs.yml) | Sundays at 00:00 UTC | Delete old workflow runs (retain 7 days, min 5) and prune merged-branch caches |
 
 [Renovate](https://docs.renovatebot.com/) keeps dependencies up to date with platform automerge enabled.
 

--- a/container-structure-test.yaml
+++ b/container-structure-test.yaml
@@ -1,0 +1,23 @@
+schemaVersion: 2.0.0
+
+# Container structure validation for the flight-path runtime image.
+# Run via `make image-structure-test` locally and the `docker` job in CI.
+# Complements the Trivy CVE scan and smoke test by asserting Dockerfile-level
+# invariants that smoke testing alone cannot verify (binary path, ownership,
+# metadata, entrypoint, healthcheck).
+
+fileExistenceTests:
+  - name: 'main binary exists at /main'
+    path: '/main'
+    shouldExist: true
+
+fileContentTests:
+  - name: 'srvuser is a normal user (uid 1000) in /etc/passwd'
+    path: '/etc/passwd'
+    expectedContents: ['srvuser:x:1000:1000']
+
+metadataTest:
+  entrypoint: ['/main']
+  user: 'srvuser:srvgroup'
+  # No ENV / EXPOSE / CMD assertions: we don't pin port via EXPOSE (it's
+  # documentation-only and SERVER_PORT comes from .env / env at runtime).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,37 +1,14 @@
 # Architecture
 
-C4 model diagrams and request/CI workflow diagrams for the Flight Path API.
-
-## C4 Context Diagram
-
-Shows the system boundary and external actors interacting with the Flight Path API.
-
-```mermaid
-C4Context
-    title System Context Diagram - Flight Path API
-
-    Person(user, "API Client", "Developer or application consuming the Flight Path API")
-
-    System(flightpath, "Flight Path API", "Go microservice that calculates flight paths from unordered flight segments")
-
-    System_Ext(swagger, "Swagger UI", "Auto-generated API documentation and interactive testing")
-    System_Ext(ci, "GitHub Actions CI", "Automated build, test, security scan, and image scan pipeline")
-
-    Rel(user, flightpath, "POST /calculate, GET /", "HTTP/JSON")
-    Rel(user, swagger, "Browses API docs", "HTTP")
-    Rel(swagger, flightpath, "Serves from /swagger/*", "HTTP")
-    Rel(ci, flightpath, "Builds, tests, scans", "CI pipeline")
-
-    UpdateLayoutConfig($c4ShapeInRow="3")
-```
+C4 Container, request-flow sequence, and CI/CD pipeline diagrams for the Flight Path API. The System Context diagram lives in the project [README](../README.md#overview).
 
 ## C4 Container Diagram
 
 flight-path ships as **one runnable container** — a statically-linked Go binary
 that embeds the HTTP server, routing, handlers, the `FindItinerary` algorithm,
-and the Swagger UI (via `swaggo/echo-swagger`). The diagram below matches that
-reality. For the internal module structure inside that one container (routes,
-handlers, algorithm, data models) see the Component diagram below.
+and the Swagger UI (via `swaggo/echo-swagger`). It has no datastore, message
+broker, cache, or third-party API dependency at runtime — the diagram below
+shows the complete runtime topology.
 
 ```mermaid
 C4Container
@@ -43,56 +20,13 @@ C4Container
         Container(server, "flight-path server", "Go 1.26.2, Echo v5.1.0", "Single static binary. Serves POST /calculate, GET /, and GET /swagger/* (embedded Swagger UI via swaggo/echo-swagger v2.0.1). Middleware stack: Logger, Recover, CORS, Secure, Cache-Control, Gzip, RequestID, BodyLimit 1 MiB.")
     }
 
-    System_Ext(ci, "GitHub Actions CI", "Builds, tests, scans, signs")
-    System_Ext(ghcr, "GHCR", "Hosts multi-arch signed container images")
-    System_Ext(sigstore, "Sigstore", "Cosign keyless OIDC signing + Rekor transparency log")
-
     Rel(client, server, "POST /calculate, GET /, GET /swagger/*", "HTTPS / JSON")
-    Rel(ci, server, "Builds, tests, image-scans", "make ci / make image-scan")
-    Rel(ci, ghcr, "Publishes images (on tag push)", "docker push")
-    Rel(ci, sigstore, "Signs manifests by digest", "cosign OIDC")
-
-    UpdateLayoutConfig($c4ShapeInRow="3")
 ```
 
-## C4 Component Diagram
-
-Shows the internal components and their relationships.
-
-```mermaid
-C4Component
-    title Component Diagram - Flight Path API
-
-    Container_Boundary(main_boundary, "main.go") {
-        Component(entrypoint, "main()", "Entry Point", "Loads .env, creates Echo instance, registers middleware and routes, starts server")
-    }
-
-    Container_Boundary(routes_boundary, "internal/routes/") {
-        Component(flight_routes, "FlightRoutes", "Route Registration", "POST /calculate -> FlightCalculate")
-        Component(health_routes, "HealthcheckRoutes", "Route Registration", "GET / -> ServerHealthCheck")
-        Component(swagger_routes, "SwaggerRoutes", "Route Registration", "GET /swagger/* -> Swagger UI")
-    }
-
-    Container_Boundary(handlers_boundary, "internal/handlers/") {
-        Component(handler_struct, "Handler struct", "Constructor", "New() creates Handler instance")
-        Component(flight_handler, "FlightCalculate", "Handler Method", "Binds [][]string, validates segments, calls FindItinerary, returns [start, end]")
-        Component(health_handler, "ServerHealthCheck", "Handler Method", "Returns server status JSON")
-        Component(find_itinerary, "FindItinerary", "Algorithm", "O(n) two-pass map algorithm: finds airport with no incoming (start) and no outgoing (end)")
-    }
-
-    Container_Boundary(pkg_boundary, "pkg/api/") {
-        Component(flight_model, "Flight", "Data Model", "struct { Start string, End string }")
-    }
-
-    Rel(entrypoint, flight_routes, "Registers")
-    Rel(entrypoint, health_routes, "Registers")
-    Rel(entrypoint, swagger_routes, "Registers")
-    Rel(flight_routes, flight_handler, "Routes to")
-    Rel(health_routes, health_handler, "Routes to")
-    Rel(flight_handler, find_itinerary, "Calls")
-    Rel(find_itinerary, flight_model, "Uses")
-    Rel(flight_handler, flight_model, "Converts payload to")
-```
+The internal package layout (`internal/{routes,handlers}`, `pkg/api/`) mirrors
+the layered-architecture table in the [README Architecture section](../README.md#architecture)
+— there is no Component-level surprise that warrants a separate C4 Component
+diagram.
 
 ## Request Flow — POST /calculate
 
@@ -134,56 +68,55 @@ sequenceDiagram
 
 ## CI/CD Pipeline
 
-GitHub Actions workflow showing the build, test, and security scanning pipeline.
+The single workflow at [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) runs on every push, pull request, and `v*` tag. A `changes` paths-filter gates every heavy job on whether the push touches code; `ci-pass` is the single required status check for branch protection.
 
 ```mermaid
 flowchart TD
-    trigger["Push / Pull Request"] --> static
+    trigger["push / pull_request / tag v*"] --> changes["changes<br/>(dorny/paths-filter)"]
 
-    subgraph static["Static Check"]
-        lint["golangci-lint<br/>(60+ linters)"]
-        sec["gosec<br/>(security scanner)"]
-        vuln["govulncheck<br/>(dependency CVEs)"]
-        secrets["gitleaks<br/>(secrets detection)"]
-        actionlint["actionlint<br/>(CI lint)"]
-        trivyfs["Trivy filesystem<br/>(vuln + secret + misconfig)"]
-    end
+    changes -->|code = true| static["static-check<br/>(make static-check)"]
+    changes -->|code = true| build["build<br/>(upload binary)"]
 
-    static --> builds["Build Binary"]
-    builds --> tests
+    static --> test["test<br/>(coverage 80% + fuzz)"]
+    static --> integ["integration-test<br/>(httptest, //go:build integration)"]
 
-    subgraph tests["Tests"]
-        unit["Unit + Handler Tests<br/>(go test ./...)"]
-        fuzz["Fuzz Tests<br/>(30 seconds)"]
-    end
+    build --> e2e["e2e<br/>(Newman / Postman, 18 cases)"]
+    test --> e2e
+    build --> dast["dast<br/>(OWASP ZAP, skipped under act)"]
+    test --> dast
 
-    builds --> imgscan
+    static --> docker
+    build --> docker
+    test --> docker
 
-    subgraph imgscan["Image Scan"]
-        docker["Build Docker Image"]
-        trivyimg["Trivy Image Scan<br/>(CRITICAL + HIGH)"]
-        docker --> trivyimg
-    end
+    docker["docker<br/>build → Trivy → smoke → multi-arch<br/>(push + cosign sign on tag)"]
 
-    tests --> integration
+    e2e --> goreleaser
+    dast --> goreleaser
+    integ --> goreleaser
+    static --> goreleaser
+    build --> goreleaser
+    test --> goreleaser
+    goreleaser["goreleaser<br/>(tag only)"] --> docker
 
-    subgraph integration["Integration Tests"]
-        start["Build + Start Server"]
-        newman["Newman/Postman E2E<br/>(6 test cases)"]
-        start --> newman
-    end
+    changes --> pass
+    static --> pass
+    build --> pass
+    test --> pass
+    integ --> pass
+    e2e --> pass
+    dast --> pass
+    goreleaser --> pass
+    docker --> pass
+    pass["ci-pass<br/>(required status check)"]
 
-    integration --> dast
-
-    subgraph dast["DAST"]
-        zapstart["Build + Start Server"]
-        zap["OWASP ZAP API Scan<br/>(via Swagger spec)"]
-        zapstart --> zap
-    end
-
+    style changes fill:#fff3e0
     style static fill:#e1f5fe
-    style tests fill:#e8f5e9
-    style integration fill:#fff3e0
+    style test fill:#e8f5e9
+    style integ fill:#e8f5e9
+    style e2e fill:#e8f5e9
     style dast fill:#fce4ec
-    style imgscan fill:#f3e5f5
+    style docker fill:#f3e5f5
+    style goreleaser fill:#f3e5f5
+    style pass fill:#c8e6c9
 ```

--- a/internal/app/app_integration_test.go
+++ b/internal/app/app_integration_test.go
@@ -8,9 +8,10 @@ package app_test
 
 import (
 	"bytes"
-	"io"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 
@@ -55,6 +56,13 @@ func TestHealthCheckSecurityHeaders(t *testing.T) {
 			t.Errorf("%s: want %q, got %q", k, v, got)
 		}
 	}
+	var body map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body["data"] == "" {
+		t.Errorf("health body missing non-empty data field: %v", body)
+	}
 }
 
 func TestCORSDefaultWildcard(t *testing.T) {
@@ -95,6 +103,22 @@ func TestCORSPreflight(t *testing.T) {
 	}
 }
 
+func TestCORSPreflightCustomOrigin(t *testing.T) {
+	s := newTestServer(t, map[string]string{"CORS_ORIGIN": "https://app.example"})
+	req := must(http.NewRequest(http.MethodOptions, s.URL+"/calculate", nil))
+	req.Header.Set("Origin", "https://app.example")
+	req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+	req.Header.Set("Access-Control-Request-Headers", "Content-Type")
+	resp := do(t, req)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		t.Errorf("preflight: want 204 or 200, got %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "https://app.example" {
+		t.Errorf("preflight Access-Control-Allow-Origin: want https://app.example, got %q", got)
+	}
+}
+
 func TestCalculateHappyPath(t *testing.T) {
 	s := newTestServer(t, nil)
 	body := bytes.NewBufferString(`[["SFO","ATL"],["ATL","EWR"]]`)
@@ -105,9 +129,84 @@ func TestCalculateHappyPath(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("want 200, got %d", resp.StatusCode)
 	}
-	b, _ := io.ReadAll(resp.Body)
-	if !strings.Contains(string(b), `"SFO"`) || !strings.Contains(string(b), `"EWR"`) {
-		t.Errorf("body missing start/end airports: %s", string(b))
+	var got []string
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	want := []string{"SFO", "EWR"}
+	if !slices.Equal(got, want) {
+		t.Errorf("body: want %v, got %v", want, got)
+	}
+}
+
+func TestCalculateEmptyArray(t *testing.T) {
+	s := newTestServer(t, nil)
+	body := bytes.NewBufferString(`[]`)
+	req := must(http.NewRequest(http.MethodPost, s.URL+"/calculate", body))
+	req.Header.Set("Content-Type", "application/json")
+	resp := do(t, req)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", resp.StatusCode)
+	}
+	var env map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	msg, _ := env["Error"].(string)
+	if !strings.Contains(strings.ToLower(msg), "empty") {
+		t.Errorf("Error: want substring 'empty', got %q", msg)
+	}
+	if _, hasIndex := env["Index"]; hasIndex {
+		t.Errorf("empty-array response should not include Index field, got %v", env)
+	}
+}
+
+func TestCalculateMalformedJSON(t *testing.T) {
+	s := newTestServer(t, nil)
+	body := bytes.NewBufferString(`not valid json`)
+	req := must(http.NewRequest(http.MethodPost, s.URL+"/calculate", body))
+	req.Header.Set("Content-Type", "application/json")
+	resp := do(t, req)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", resp.StatusCode)
+	}
+	var env map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	msg, _ := env["Error"].(string)
+	if !strings.Contains(strings.ToLower(msg), "parse") {
+		t.Errorf("Error: want substring 'parse', got %q", msg)
+	}
+}
+
+func TestCalculateIncompleteSegmentBody(t *testing.T) {
+	s := newTestServer(t, nil)
+	// Second segment is incomplete — handler should report Error + Index=1.
+	body := bytes.NewBufferString(`[["SFO","EWR"],["JFK"]]`)
+	req := must(http.NewRequest(http.MethodPost, s.URL+"/calculate", body))
+	req.Header.Set("Content-Type", "application/json")
+	resp := do(t, req)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", resp.StatusCode)
+	}
+	var env map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	msg, _ := env["Error"].(string)
+	if !strings.Contains(strings.ToLower(msg), "source and destination") {
+		t.Errorf("Error: want substring 'source and destination', got %q", msg)
+	}
+	idx, ok := env["Index"].(float64) // JSON numbers decode to float64 in map[string]any
+	if !ok {
+		t.Fatalf("Index: want number, got %T (body: %v)", env["Index"], env)
+	}
+	if int(idx) != 1 {
+		t.Errorf("Index: want 1, got %v", idx)
 	}
 }
 

--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
     "gomod",
     "github-actions",
     "dockerfile",
+    "mise",
     "npm",
     "custom.regex"
   ],
@@ -99,11 +100,11 @@
       ]
     },
     {
-      "description": "Group Makefile tool version updates",
+      "description": "Group toolchain pins (Makefile and .mise.toml inline-renovate-comment updates)",
       "matchManagers": [
         "custom.regex"
       ],
-      "groupName": "Makefile tools"
+      "groupName": "Toolchain pins"
     },
     {
       "description": "Group Node.js dependencies",


### PR DESCRIPTION
## Summary

Sweep of project-review findings + test-coverage Phase 4 + Docker hardening additive (container-structure-test).

### Foundation (Phase A)

- **renovate.json**: enable `mise` manager; rename `Makefile tools` group to `Toolchain pins` (covers both Makefile and `.mise.toml`)
- **Makefile**: add `format-check` (non-mutating CI gate, replaces `format` in the `ci` chain); add release upstream-tracking precheck; new `image-structure-test` target wired into `image-test`; fix `bench-compare` shell-variable scoping bug
- **ci.yml**: drop decorative parentheticals from step names (`Set up mise`, `Build`, `Decide code output`); add Gate 3b (container structure test) to `docker` job
- **claude.yml**: switch `claude-pr-review` from author_association blocklist to explicit allowlist (OWNER/MEMBER/COLLABORATOR + `renovate[bot]`)
- **.mise.toml**: pin `container-structure-test 1.22.1` (aqua backend, Renovate-tracked)

### Test coverage tightening

- `internal/app/app_integration_test.go`: +4 integration tests (empty array, malformed JSON, incomplete-segment `Index`, custom-origin preflight) + 2 tightened (health body shape, happy-path `slices.Equal`). Suite now 16 tests.

### Docker image hardening

- New `container-structure-test.yaml`: assert `/main` binary exists, `srvuser:1000:1000` in `/etc/passwd`, entrypoint and USER metadata. Wired into `make image-test` locally and Gate 3b in CI's `docker` job.

### Documentation (Phase B)

- **docs/ARCHITECTURE.md**: drop C4Component diagram (CRUD restated); rewrite CI/CD flowchart with current jobs (`changes/static-check/build/test/integration-test/e2e/dast/goreleaser/docker/ci-pass`, 18 Newman cases); clean Container view of build/release externals (CI/GHCR/Sigstore moved out — they're build-time, not runtime); remove duplicate Context (now lives only in README)
- **README.md**: drop GHCR/Sigstore from runtime Context hero; add Companion Workflows table including `auto-merge.yml`; rewrite Postman section in imperative tense; add `format-check` + `image-structure-test` to targets table; sync `static-check`/`ci` chain descriptions
- **CLAUDE.md**: correct Newman case count (11 → 18); add `format-check`, `image-structure-test`, and `container-structure-test` to Common Commands and Dev Tools

## Test plan

- [x] `make ci` — full chain (deps + static-check + test + integration-test + coverage-check + build + fuzz + deps-prune-check)
- [x] `make e2e` — Newman: 18 requests, 53 assertions, 0 failures
- [x] `make image-test` — image-build + image-smoke-test + image-structure-test (3/3 PASS)
- [x] `make image-scan` / `trivy-image` — 0 vulnerabilities, 0 secrets
- [x] `make coverage` — 97.4% (>80% threshold)
- [x] `make bench-compare` — auto-discovers latest two saved benches (after fix)
- [x] `make renovate-validate` — clean; `Toolchain pins` group recognized
- [ ] CI green on this PR