### PR TITLE
chore: project-review remediation — secret fix, CI hygiene, e2e ephemeral port, integration parity

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -4,16 +4,17 @@ on:
   pull_request:
     types: [opened, ready_for_review]
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
-  enable:
+  auto-merge:
     if: >-
       !github.event.pull_request.draft &&
       github.event.pull_request.user.login == 'AndriyKalashnykov'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Enable auto-merge (squash)
         # `--repo` is required because the job has no `actions/checkout` step,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,7 +254,7 @@ jobs:
           ./server -env-file .env &
           ./scripts/wait-for-server.sh
 
-      - name: Run Postman/Newman tests
+      - name: Run Newman tests
         run: make e2e-quick
 
   dast:
@@ -409,7 +409,11 @@ jobs:
         id: meta
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
-          images: ghcr.io/andriykalashnykov/flight-path
+          # docker/metadata-action lowercases the registry path automatically,
+          # so this expands to ghcr.io/andriykalashnykov/flight-path even though
+          # github.repository preserves owner casing. Dynamic form survives
+          # repo rename/fork — see /harden-image-pipeline §"GHCR namespace rule".
+          images: ghcr.io/${{ github.repository }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -471,6 +475,7 @@ jobs:
       - name: Install container-structure-test
         run: |
           set -euo pipefail
+          # renovate: datasource=github-releases depName=GoogleContainerTools/container-structure-test
           CST_VERSION=1.22.1
           curl -fsSL -o /tmp/cst "https://github.com/GoogleContainerTools/container-structure-test/releases/download/v${CST_VERSION}/container-structure-test-linux-amd64"
           install -m 0755 /tmp/cst /usr/local/bin/container-structure-test

--- a/Makefile
+++ b/Makefile
@@ -145,9 +145,19 @@ bench-compare: deps
 	fi
 
 #lint: @ Run golangci-lint and hadolint (comprehensive linting via .golangci.yml)
-lint: deps
+lint: deps lint-scripts-exec
 	@$(call go-exec,golangci-lint run ./...)
 	@hadolint Dockerfile
+
+#lint-scripts-exec: @ Verify all shell scripts are executable (catches subagent 0644 writes)
+lint-scripts-exec:
+	@NONEXEC=$$(find scripts -name '*.sh' -not -executable -print 2>/dev/null); \
+	if [ -n "$$NONEXEC" ]; then \
+		echo "Error: shell scripts missing +x:"; \
+		echo "$$NONEXEC" | sed 's/^/  /'; \
+		echo "Fix with: chmod +x <file>"; \
+		exit 1; \
+	fi
 
 #vulncheck: @ Run Go vulnerability check on dependencies
 vulncheck: deps
@@ -344,14 +354,25 @@ ci-run: deps
 	@EVENT=$$(mktemp /tmp/act-push-event.XXXXXX.json); \
 	printf '{"repository":{"default_branch":"main"},"ref":"refs/heads/main","before":"0000000000000000000000000000000000000000","after":"0000000000000000000000000000000000000000"}' > $$EVENT; \
 	if [ -f ~/.secrets ]; then . ~/.secrets; fi; \
-	act push -W .github/workflows/ci.yml \
-		--eventpath $$EVENT \
-		--container-architecture linux/amd64 \
-		--artifact-server-path /tmp/act-artifacts \
-		--var ACT=true \
-		$${GITHUB_TOKEN:+-s GITHUB_TOKEN=$$GITHUB_TOKEN}; \
-	RC=$$?; \
+	ACT_PORT=$$(shuf -i 40000-59999 -n 1); \
+	ARTIFACT_PATH=$$(mktemp -d -t act-artifacts.XXXXXX); \
+	secret_args=(); \
+	if [ -n "$$GITHUB_TOKEN" ]; then secret_args+=(--secret GITHUB_TOKEN); fi; \
+	RC=0; \
+	for job in static-check build test integration-test e2e docker; do \
+		echo "=== act job: $$job ==="; \
+		act push -W .github/workflows/ci.yml \
+			--job $$job \
+			--eventpath $$EVENT \
+			--container-architecture linux/amd64 \
+			--pull=false \
+			--artifact-server-port "$$ACT_PORT" \
+			--artifact-server-path "$$ARTIFACT_PATH" \
+			--var ACT=true \
+			"$${secret_args[@]}" || { RC=$$?; break; }; \
+	done; \
 	rm -f $$EVENT; \
+	rm -rf "$$ARTIFACT_PATH"; \
 	exit $$RC
 
 #check: @ Run pre-commit checklist (alias for ci)
@@ -371,12 +392,20 @@ trivy-image: deps
 	@trivy image --severity CRITICAL,HIGH --exit-code 1 $(APP_NAME):scan
 
 #e2e: @ Build + start server + run e2e + stop server (self-contained; called by `make ci`)
+# Allocates an ephemeral port via scripts/pick-port.sh so parallel runs
+# (two checkouts, sibling repos under a single dev machine, multi-job CI)
+# don't collide on a fixed 8080. Newman gets baseUrl via --env-var.
 e2e: deps build
-	@pkill -x server 2>/dev/null || true
-	@./server -env-file .env >/tmp/flight-path-e2e.log 2>&1 &
-	@./scripts/wait-for-server.sh
-	@EXIT=0; ./test/node_modules/.bin/newman run $(NEWMANTESTSLOCATION)FlightPath.postman_collection.json || EXIT=$$?; \
-		pkill -x server 2>/dev/null || true; \
+	@PORT=$$(./scripts/pick-port.sh); \
+		BASE="http://localhost:$$PORT"; \
+		PIDFILE=$$(mktemp -t flight-path-e2e.XXXXXX.pid); \
+		SERVER_PORT=$$PORT ./server -env-file .env >/tmp/flight-path-e2e.log 2>&1 & echo $$! > "$$PIDFILE"; \
+		./scripts/wait-for-server.sh "$$BASE/" 30; \
+		EXIT=0; \
+		./test/node_modules/.bin/newman run $(NEWMANTESTSLOCATION)FlightPath.postman_collection.json \
+			--env-var "baseUrl=$$BASE" || EXIT=$$?; \
+		kill "$$(cat "$$PIDFILE")" 2>/dev/null || true; \
+		rm -f "$$PIDFILE"; \
 		exit $$EXIT
 
 #e2e-quick: @ Run Postman/Newman end-to-end tests (requires server already running)
@@ -435,7 +464,7 @@ deps-prune-check: deps
 	@echo "No prunable dependencies found."
 
 .PHONY: help deps deps-check api-docs test integration-test fuzz bench bench-save bench-compare \
-	lint vulncheck secrets sec lint-ci format format-check static-check mermaid-lint release-check build run release update open-swagger \
+	lint lint-scripts-exec vulncheck secrets sec lint-ci format format-check static-check mermaid-lint release-check build run release update open-swagger \
 	test-case-one test-case-two test-case-three e2e e2e-quick clean coverage coverage-check \
 	ci ci-run check trivy-fs trivy-image \
 	image-build image-run image-stop image-push image-smoke-test image-structure-test image-test image-scan \

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # Go REST API to reconstruct flight paths from unordered segments
 
-A Go REST API microservice that calculates flight paths from unordered flight segments. Given a list of [source, destination] pairs, it determines the complete path (starting airport to ending airport).
+A Go REST API microservice that calculates flight paths from unordered flight segments. Given a list of [source, destination] pairs, it determines the complete path from start to end airport.
 
 ## Overview
 
@@ -15,6 +15,7 @@ C4Context
     Person(client, "API Client", "cURL, Postman, Newman, browser")
     System(flightpath, "flight-path", "Go REST API that reconstructs full itinerary from unordered flight segments")
     Rel(client, flightpath, "POST /calculate", "HTTPS/JSON")
+    UpdateLayoutConfig($c4ShapeInRow="2")
 ```
 
 See [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md) for Container, request-flow sequence, and CI/CD pipeline diagrams.

--- a/benchmarks/bench_20260503_004123.txt
+++ b/benchmarks/bench_20260503_004123.txt
@@ -1,0 +1,10 @@
+goos: linux
+goarch: amd64
+pkg: github.com/AndriyKalashnykov/flight-path/internal/handlers
+cpu: 12th Gen Intel(R) Core(TM) i9-12900KF
+BenchmarkFindItinerary_10-24     	 6553833	       537.7 ns/op	     912 B/op	       6 allocs/op
+BenchmarkFindItinerary_50-24     	 1599726	      2235 ns/op	    3664 B/op	       6 allocs/op
+BenchmarkFindItinerary_100-24    	  750765	      4270 ns/op	    6992 B/op	       6 allocs/op
+BenchmarkFindItinerary_500-24    	  171912	     20671 ns/op	   54608 B/op	       6 allocs/op
+PASS
+ok  	github.com/AndriyKalashnykov/flight-path/internal/handlers	16.957s

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -66,6 +66,34 @@ sequenceDiagram
     H-->>C: 200 ["SFO", "EWR"]
 ```
 
+## Request Flow — CORS preflight + security headers
+
+Browser-initiated cross-origin requests issue an `OPTIONS` preflight before the
+actual `POST`. The CORS middleware answers preflight; the Secure middleware
+attaches headers (XCTO, XFO, CSP, HSTS, XSS-Protection, Referrer-Policy) and
+Cache-Control / Cross-Origin-Resource-Policy on every response.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant B as Browser
+    participant E as Echo Server
+    participant CORS as CORS Middleware
+    participant SEC as Secure + Cache Middleware
+    participant H as FlightCalculate Handler
+
+    B->>E: OPTIONS /calculate<br/>Origin, Access-Control-Request-Method, -Headers
+    E->>CORS: preflight
+    CORS-->>B: 204 No Content<br/>Access-Control-Allow-Origin: * (or CORS_ORIGIN)<br/>Access-Control-Allow-Methods: GET, POST, OPTIONS
+
+    B->>E: POST /calculate (real request)
+    E->>CORS: pass through
+    CORS->>SEC: pass through
+    SEC->>H: handler invoked
+    H-->>SEC: 200 ["SFO", "EWR"]
+    SEC-->>B: 200 + security headers<br/>(XCTO, XFO, XSS-Protection, Referrer-Policy,<br/>Cache-Control, Cross-Origin-Resource-Policy)
+```
+
 ## CI/CD Pipeline
 
 The single workflow at [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) runs on every push, pull request, and `v*` tag. A `changes` paths-filter gates every heavy job on whether the push touches code; `ci-pass` is the single required status check for branch protection.

--- a/internal/app/app_integration_test.go
+++ b/internal/app/app_integration_test.go
@@ -47,6 +47,7 @@ func TestHealthCheckSecurityHeaders(t *testing.T) {
 	wantHeaders := map[string]string{
 		"X-Content-Type-Options":       "nosniff",
 		"X-Frame-Options":              "DENY",
+		"X-XSS-Protection":             "1; mode=block",
 		"Referrer-Policy":              "strict-origin-when-cross-origin",
 		"Cross-Origin-Resource-Policy": "same-origin",
 		"Cache-Control":                "no-store",
@@ -298,6 +299,155 @@ func TestPortFromEnv(t *testing.T) {
 	if got := app.Port(); got != "9090" {
 		t.Errorf("Port from env: want 9090, got %s", got)
 	}
+}
+
+// TestCalculateEmptyBody covers POSTing with no payload at all (Content-Length: 0).
+// Mirrors Newman cases that exercise the bind-failure path through the full
+// middleware chain — the unit tests use httptest.NewRecorder and skip middleware.
+func TestCalculateEmptyBody(t *testing.T) {
+	s := newTestServer(t, nil)
+	req := must(http.NewRequest(http.MethodPost, s.URL+"/calculate", http.NoBody))
+	req.Header.Set("Content-Type", "application/json")
+	resp := do(t, req)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", resp.StatusCode)
+	}
+	var env map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	msg, _ := env["Error"].(string)
+	if msg == "" {
+		t.Errorf("Error: want non-empty error message, got %q", msg)
+	}
+}
+
+// TestCalculateObjectRoot mirrors Newman UseCase09: a JSON object root instead
+// of an array — must fail bind with a parse-style error.
+func TestCalculateObjectRoot(t *testing.T) {
+	s := newTestServer(t, nil)
+	body := bytes.NewBufferString(`{"foo":"bar"}`)
+	req := must(http.NewRequest(http.MethodPost, s.URL+"/calculate", body))
+	req.Header.Set("Content-Type", "application/json")
+	resp := do(t, req)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", resp.StatusCode)
+	}
+	var env map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	msg, _ := env["Error"].(string)
+	if !strings.Contains(strings.ToLower(msg), "parse") {
+		t.Errorf("Error: want substring 'parse', got %q", msg)
+	}
+}
+
+// TestCalculateExtraItemsIgnored mirrors Newman UseCase07: extra elements
+// past the second in a segment must be silently ignored — first two used.
+func TestCalculateExtraItemsIgnored(t *testing.T) {
+	s := newTestServer(t, nil)
+	body := bytes.NewBufferString(`[["SFO","EWR","JFK"]]`)
+	req := must(http.NewRequest(http.MethodPost, s.URL+"/calculate", body))
+	req.Header.Set("Content-Type", "application/json")
+	resp := do(t, req)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+	var got []string
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	want := []string{"SFO", "EWR"}
+	if !slices.Equal(got, want) {
+		t.Errorf("body: want %v, got %v", want, got)
+	}
+}
+
+// TestCalculate100SegmentChain mirrors Newman UseCase13: a scrambled 100-segment
+// chain protects against algorithm regressions at scale through the HTTP layer.
+// Builds A0→A1→...→A100, scrambles, posts, and asserts start/end.
+func TestCalculate100SegmentChain(t *testing.T) {
+	s := newTestServer(t, nil)
+	const n = 100
+	segments := make([][]string, 0, n)
+	for i := 0; i < n; i++ {
+		segments = append(segments, []string{
+			"A" + itoa(i),
+			"A" + itoa(i+1),
+		})
+	}
+	// Deterministic scramble: reverse halves and interleave.
+	mid := n / 2
+	scrambled := make([][]string, 0, n)
+	for i := 0; i < mid; i++ {
+		scrambled = append(scrambled, segments[mid-1-i])
+		scrambled = append(scrambled, segments[n-1-i])
+	}
+	body, err := json.Marshal(scrambled)
+	if err != nil {
+		t.Fatalf("marshal segments: %v", err)
+	}
+	req := must(http.NewRequest(http.MethodPost, s.URL+"/calculate", bytes.NewReader(body)))
+	req.Header.Set("Content-Type", "application/json")
+	resp := do(t, req)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+	var got []string
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	want := []string{"A0", "A" + itoa(n)}
+	if !slices.Equal(got, want) {
+		t.Errorf("body: want %v, got %v", want, got)
+	}
+}
+
+// TestSwaggerIndexServesHTML mirrors Newman Swagger_UI: GET /swagger/index.html
+// must return HTML containing 'swagger-ui' so the embedded UI bootstraps.
+func TestSwaggerIndexServesHTML(t *testing.T) {
+	s := newTestServer(t, nil)
+	resp := do(t, must(http.NewRequest(http.MethodGet, s.URL+"/swagger/index.html", nil)))
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+	buf := new(bytes.Buffer)
+	if _, err := buf.ReadFrom(resp.Body); err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if !strings.Contains(buf.String(), "swagger-ui") {
+		t.Errorf("body missing 'swagger-ui' marker (first 200 chars): %q", buf.String()[:min(200, buf.Len())])
+	}
+}
+
+// itoa is a tiny strconv-free helper — keeps the test file's import surface
+// to what it already pulls in.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
 }
 
 func must(req *http.Request, err error) *http.Request {

--- a/renovate.json
+++ b/renovate.json
@@ -32,6 +32,16 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)( extractVersion=(?<extractVersion>[^\\s]+))?( versioning=(?<versioning>[^\\s]+))?\\n\"?[a-zA-Z0-9_:./-]+\"?\\s*=\\s*\"(?<currentValue>[^\"]+)\""
       ]
+    },
+    {
+      "customType": "regex",
+      "description": "Update inline VAR= pins in workflow run blocks via # renovate: comments (e.g. CST_VERSION in ci.yml — kept inline because the docker job intentionally doesn't use mise)",
+      "managerFilePatterns": [
+        "/^\\.github/workflows/.+\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)( versioning=(?<versioning>[^\\s]+))?\\s+\\n\\s*[A-Z_]+=(?<currentValue>[^\\s]+)"
+      ]
     }
   ],
   "postUpdateOptions": [

--- a/scripts/pick-port.sh
+++ b/scripts/pick-port.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Print a free TCP port from the kernel's ephemeral range.
+# Binds port 0 (kernel-allocated), reads back the assigned port, releases it.
+# There is a small TOCTOU window between this script exiting and the caller
+# binding — acceptable for test/CI use, not production. Used by `make e2e`
+# to allow parallel runs side-by-side without colliding on a fixed port.
+#
+# Falls back across implementations because GitHub-Actions runners and
+# developer laptops differ in what's installed by default.
+set -euo pipefail
+
+# Preferred: Python — present on every Ubuntu image and macOS 12+.
+if command -v python3 >/dev/null 2>&1; then
+  python3 -c 'import socket; s=socket.socket(); s.bind(("",0)); print(s.getsockname()[1]); s.close()'
+  exit 0
+fi
+
+# Fallback: GNU netcat with -l -p 0. BSD nc on macOS does not support -p,
+# so we don't try it — Python covers the macOS path above.
+if command -v ss >/dev/null 2>&1; then
+  # Pick a high port not in use. 32 attempts to avoid pathological cases.
+  for _ in $(seq 1 32); do
+    p=$((40000 + RANDOM % 20000))
+    if ! ss -tln "sport = :$p" 2>/dev/null | grep -q ":$p"; then
+      echo "$p"
+      exit 0
+    fi
+  done
+fi
+
+echo "pick-port.sh: no python3 or ss available — install python3 or use a fixed SERVER_PORT" >&2
+exit 1

--- a/test/FlightPath.postman_collection.json
+++ b/test/FlightPath.postman_collection.json
@@ -1,908 +1,891 @@
 {
-	"info": {
-		"_postman_id": "c86d49fc-4957-4030-bf09-554f318aea89",
-		"name": "FlightPath",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "21490464"
-	},
-	"event": [
-		{
-			"listen": "prerequest",
-			"script": {
-				"type": "text/javascript",
-				"exec": [
-					"// Global JSON schemas for Ajv response validation.",
-					"// These schemas only apply to the /calculate endpoint; the",
-					"// collection-level test script below guards on the URL so other",
-					"// endpoints (e.g. GET /) can use their own per-request assertions.",
-					"",
-					"// Success: array of exactly 2 IATA airport codes (3 uppercase letters)",
-					"var successSchema = {",
-					"    type: \"array\",",
-					"    items: { type: \"string\", pattern: \"^[A-Z]{3}$\" },",
-					"    minItems: 2,",
-					"    maxItems: 2",
-					"};",
-					"",
-					"// Error: object with required Error string, optional Index integer",
-					"var errorSchema = {",
-					"    type: \"object\",",
-					"    required: [\"Error\"],",
-					"    properties: {",
-					"        Error: { type: \"string\", minLength: 1 },",
-					"        Index: { type: \"integer\" }",
-					"    },",
-					"    additionalProperties: false",
-					"};",
-					"",
-					"pm.globals.set(\"successSchema\", JSON.stringify(successSchema));",
-					"pm.globals.set(\"errorSchema\", JSON.stringify(errorSchema));"
-				]
-			}
-		},
-		{
-			"listen": "test",
-			"script": {
-				"type": "text/javascript",
-				"exec": [
-					"// Collection-level schema validation runs for every POST /calculate request.",
-					"// Non-/calculate endpoints (e.g. GET /) and non-POST methods on /calculate",
-					"// (e.g. UseCase11 wrong-method negative case) are skipped — those requests",
-					"// use per-request assertions only.",
-					"if (!pm.request.url.getPath().endsWith('/calculate') || pm.request.method !== 'POST') {",
-					"    return;",
-					"}",
-					"",
-					"var Ajv = require('ajv');",
-					"var ajv = new Ajv({ allErrors: true });",
-					"var schemaKey = pm.response.code === 200 ? \"successSchema\" : \"errorSchema\";",
-					"var schema = JSON.parse(pm.globals.get(schemaKey));",
-					"var validate = ajv.compile(schema);",
-					"",
-					"pm.test(\"Response matches JSON schema\", function () {",
-					"    var valid = validate(pm.response.json());",
-					"    pm.expect(valid, valid ? '' : ajv.errorsText(validate.errors)).to.be.true;",
-					"});"
-				]
-			}
-		}
-	],
-	"item": [
-		{
-			"name": "HealthCheck",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"status code is 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							"",
-							"pm.test(\"Response has data field\", function () {",
-							"    var responseJSON = pm.response.json();",
-							"    pm.expect(responseJSON).to.have.property('data');",
-							"    pm.expect(responseJSON.data).to.be.a('string');",
-							"    pm.expect(responseJSON.data.length).to.be.above(0);",
-							"});"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [],
-				"url": {
-					"raw": "http://localhost:8080/",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "8080",
-					"path": [
-						""
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "UseCase01",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"status code is 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							"",
-							"pm.test(\"Response has correct airports\", function () {",
-							"    var responseJSON = pm.response.json();",
-							"    pm.expect(responseJSON[0]).to.equal(\"SFO\");",
-							"    pm.expect(responseJSON[1]).to.equal(\"EWR\");",
-							"});"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "[[\"SFO\", \"EWR\"]]",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "http://localhost:8080/calculate",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "8080",
-					"path": [
-						"calculate"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "UseCase02",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"status code is 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							"",
-							"pm.test(\"Response has correct airports\", function () {",
-							"    var responseJSON = pm.response.json();",
-							"    pm.expect(responseJSON[0]).to.equal(\"SFO\");",
-							"    pm.expect(responseJSON[1]).to.equal(\"EWR\");",
-							"});"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "[[\"ATL\", \"EWR\"], [\"SFO\", \"ATL\"]]",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "http://localhost:8080/calculate",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "8080",
-					"path": [
-						"calculate"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "UseCase03",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"status code is 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							"",
-							"pm.test(\"Response has correct airports\", function () {",
-							"    var responseJSON = pm.response.json();",
-							"    pm.expect(responseJSON[0]).to.equal(\"SFO\");",
-							"    pm.expect(responseJSON[1]).to.equal(\"EWR\");",
-							"});"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "[[\"IND\", \"EWR\"], [\"SFO\", \"ATL\"], [\"GSO\", \"IND\"], [\"ATL\", \"GSO\"]]",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "http://localhost:8080/calculate",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "8080",
-					"path": [
-						"calculate"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "UseCase04_EmptyBody",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"status code is 400\", function () {",
-							"    pm.response.to.have.status(400);",
-							"});",
-							"",
-							"pm.test(\"Error mentions empty segments\", function () {",
-							"    var responseJSON = pm.response.json();",
-							"    pm.expect(responseJSON.Error).to.include(\"empty\");",
-							"});"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "[]",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "http://localhost:8080/calculate",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "8080",
-					"path": [
-						"calculate"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "UseCase05_MalformedJSON",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"status code is 400\", function () {",
-							"    pm.response.to.have.status(400);",
-							"});",
-							"",
-							"pm.test(\"Error mentions parsing\", function () {",
-							"    var responseJSON = pm.response.json();",
-							"    pm.expect(responseJSON.Error).to.include(\"parse\");",
-							"});"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "not valid json",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "http://localhost:8080/calculate",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "8080",
-					"path": [
-						"calculate"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "UseCase06_IncompleteSegment",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"status code is 400\", function () {",
-							"    pm.response.to.have.status(400);",
-							"});",
-							"",
-							"pm.test(\"Error mentions source and destination\", function () {",
-							"    var responseJSON = pm.response.json();",
-							"    pm.expect(responseJSON.Error).to.include(\"source and destination\");",
-							"});"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "[[\"SFO\"]]",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "http://localhost:8080/calculate",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "8080",
-					"path": [
-						"calculate"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "UseCase07_ExtraItemsInSegmentIgnored",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"status code is 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							"",
-							"pm.test(\"Only first two elements of segment are used\", function () {",
-							"    var responseJSON = pm.response.json();",
-							"    pm.expect(responseJSON[0]).to.equal(\"SFO\");",
-							"    pm.expect(responseJSON[1]).to.equal(\"EWR\");",
-							"});"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "[[\"SFO\", \"EWR\", \"JFK\"]]",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "http://localhost:8080/calculate",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "8080",
-					"path": [
-						"calculate"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "UseCase08_TenSegmentChain",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"status code is 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							"",
-							"pm.test(\"Ten-segment scrambled chain resolves LAX to SFO\", function () {",
-							"    var responseJSON = pm.response.json();",
-							"    pm.expect(responseJSON[0]).to.equal(\"LAX\");",
-							"    pm.expect(responseJSON[1]).to.equal(\"SFO\");",
-							"});"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "[[\"ORD\",\"ATL\"],[\"LAX\",\"PHX\"],[\"JFK\",\"EWR\"],[\"BOS\",\"JFK\"],[\"PHX\",\"DEN\"],[\"EWR\",\"SEA\"],[\"DEN\",\"ORD\"],[\"ATL\",\"MIA\"],[\"SEA\",\"SFO\"],[\"MIA\",\"BOS\"]]",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "http://localhost:8080/calculate",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "8080",
-					"path": [
-						"calculate"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "UseCase09_ObjectRoot",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"status code is 400\", function () {",
-							"    pm.response.to.have.status(400);",
-							"});",
-							"",
-							"pm.test(\"Error mentions parsing\", function () {",
-							"    var responseJSON = pm.response.json();",
-							"    pm.expect(responseJSON.Error).to.include(\"parse\");",
-							"});"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\"foo\":\"bar\"}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "http://localhost:8080/calculate",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "8080",
-					"path": [
-						"calculate"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "UseCase10_SecondSegmentIncomplete",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"status code is 400\", function () {",
-							"    pm.response.to.have.status(400);",
-							"});",
-							"",
-							"pm.test(\"Error mentions source and destination\", function () {",
-							"    var responseJSON = pm.response.json();",
-							"    pm.expect(responseJSON.Error).to.include(\"source and destination\");",
-							"});",
-							"",
-							"pm.test(\"Error Index points at offending segment\", function () {",
-							"    var responseJSON = pm.response.json();",
-							"    pm.expect(responseJSON.Index).to.equal(1);",
-							"});"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "[[\"SFO\",\"EWR\"],[\"JFK\"]]",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "http://localhost:8080/calculate",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "8080",
-					"path": [
-						"calculate"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "HealthCheck_SecurityHeaders",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"status code is 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							"",
-							"pm.test(\"X-Frame-Options is DENY\", function () {",
-							"    pm.expect(pm.response.headers.get('X-Frame-Options')).to.equal('DENY');",
-							"});",
-							"",
-							"pm.test(\"X-XSS-Protection is set\", function () {",
-							"    pm.expect(pm.response.headers.get('X-XSS-Protection')).to.equal('1; mode=block');",
-							"});",
-							"",
-							"pm.test(\"X-Content-Type-Options is nosniff\", function () {",
-							"    pm.expect(pm.response.headers.get('X-Content-Type-Options')).to.equal('nosniff');",
-							"});",
-							"",
-							"pm.test(\"Referrer-Policy is strict-origin-when-cross-origin\", function () {",
-							"    pm.expect(pm.response.headers.get('Referrer-Policy')).to.equal('strict-origin-when-cross-origin');",
-							"});",
-							"",
-							"pm.test(\"Cross-Origin-Resource-Policy is same-origin\", function () {",
-							"    pm.expect(pm.response.headers.get('Cross-Origin-Resource-Policy')).to.equal('same-origin');",
-							"});",
-							"",
-							"pm.test(\"Cache-Control is no-store\", function () {",
-							"    pm.expect(pm.response.headers.get('Cache-Control')).to.equal('no-store');",
-							"});"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [],
-				"url": {
-					"raw": "http://localhost:8080/",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "8080",
-					"path": [
-						""
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "HealthCheck_CORS",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"status code is 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							"",
-							"pm.test(\"Access-Control-Allow-Origin echoes wildcard\", function () {",
-							"    // Server defaults CORS_ORIGIN to '*' when unset; Echo's CORSWithConfig",
-							"    // reflects that in Access-Control-Allow-Origin.",
-							"    pm.expect(pm.response.headers.get('Access-Control-Allow-Origin')).to.equal('*');",
-							"});"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "Origin",
-						"value": "https://example.com"
-					}
-				],
-				"url": {
-					"raw": "http://localhost:8080/",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "8080",
-					"path": [
-						""
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Swagger_UI",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"status code is 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							"",
-							"pm.test(\"Content-Type is text/html\", function () {",
-							"    pm.expect(pm.response.headers.get('Content-Type')).to.include('text/html');",
-							"});",
-							"",
-							"pm.test(\"Response body references swagger-ui\", function () {",
-							"    pm.expect(pm.response.text()).to.include('swagger-ui');",
-							"});"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [],
-				"url": {
-					"raw": "http://localhost:8080/swagger/index.html",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "8080",
-					"path": [
-						"swagger",
-						"index.html"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "UseCase11_WrongMethod",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"status code is 405 Method Not Allowed\", function () {",
-							"    pm.response.to.have.status(405);",
-							"});"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [],
-				"url": {
-					"raw": "http://localhost:8080/calculate",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "8080",
-					"path": [
-						"calculate"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "UseCase12_UnknownRoute",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"status code is 404 Not Found\", function () {",
-							"    pm.response.to.have.status(404);",
-							"});"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [],
-				"url": {
-					"raw": "http://localhost:8080/does-not-exist",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "8080",
-					"path": [
-						"does-not-exist"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "UseCase13_LargeChain",
-			"event": [
-				{
-					"listen": "prerequest",
-					"script": {
-						"type": "text/javascript",
-						"exec": [
-							"// Build a 100-segment chain AAA -> AAB -> ... -> ADW, then shuffle",
-							"// the segments so the server must reconstruct the order.",
-							"function codeFor(i) {",
-							"    return 'A' + String.fromCharCode(65 + Math.floor(i / 26)) + String.fromCharCode(65 + (i % 26));",
-							"}",
-							"var segments = [];",
-							"for (var i = 0; i < 100; i++) {",
-							"    segments.push([codeFor(i), codeFor(i + 1)]);",
-							"}",
-							"for (var j = segments.length - 1; j > 0; j--) {",
-							"    var k = Math.floor(Math.random() * (j + 1));",
-							"    var tmp = segments[j]; segments[j] = segments[k]; segments[k] = tmp;",
-							"}",
-							"pm.variables.set('largeChainBody', JSON.stringify(segments));",
-							"pm.variables.set('largeChainStart', codeFor(0));",
-							"pm.variables.set('largeChainEnd', codeFor(100));"
-						]
-					}
-				},
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"status code is 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							"",
-							"pm.test(\"Response reconstructs the full 100-segment chain\", function () {",
-							"    var responseJSON = pm.response.json();",
-							"    pm.expect(responseJSON[0]).to.equal(pm.variables.get('largeChainStart'));",
-							"    pm.expect(responseJSON[1]).to.equal(pm.variables.get('largeChainEnd'));",
-							"});"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{{largeChainBody}}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "http://localhost:8080/calculate",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "8080",
-					"path": [
-						"calculate"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "UseCase14_WrongContentType",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"status code is 400 Bad Request\", function () {",
-							"    pm.response.to.have.status(400);",
-							"});",
-							"",
-							"pm.test(\"Error message indicates parse failure\", function () {",
-							"    var responseJSON = pm.response.json();",
-							"    pm.expect(responseJSON).to.have.property('Error');",
-							"    pm.expect(responseJSON.Error).to.include(\"parse\");",
-							"});"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "text/plain"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "[[\"SFO\", \"EWR\"]]"
-				},
-				"url": {
-					"raw": "http://localhost:8080/calculate",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "8080",
-					"path": [
-						"calculate"
-					]
-				}
-			},
-			"response": []
-		}
-	]
+  "info": {
+    "_postman_id": "c86d49fc-4957-4030-bf09-554f318aea89",
+    "name": "FlightPath",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "21490464"
+  },
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          "// Global JSON schemas for Ajv response validation.",
+          "// These schemas only apply to the /calculate endpoint; the",
+          "// collection-level test script below guards on the URL so other",
+          "// endpoints (e.g. GET /) can use their own per-request assertions.",
+          "",
+          "// Success: array of exactly 2 IATA airport codes (3 uppercase letters)",
+          "var successSchema = {",
+          "    type: \"array\",",
+          "    items: { type: \"string\", pattern: \"^[A-Z]{3}$\" },",
+          "    minItems: 2,",
+          "    maxItems: 2",
+          "};",
+          "",
+          "// Error: object with required Error string, optional Index integer",
+          "var errorSchema = {",
+          "    type: \"object\",",
+          "    required: [\"Error\"],",
+          "    properties: {",
+          "        Error: { type: \"string\", minLength: 1 },",
+          "        Index: { type: \"integer\" }",
+          "    },",
+          "    additionalProperties: false",
+          "};",
+          "",
+          "pm.globals.set(\"successSchema\", JSON.stringify(successSchema));",
+          "pm.globals.set(\"errorSchema\", JSON.stringify(errorSchema));"
+        ]
+      }
+    },
+    {
+      "listen": "test",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          "// Collection-level schema validation runs for every POST /calculate request.",
+          "// Non-/calculate endpoints (e.g. GET /) and non-POST methods on /calculate",
+          "// (e.g. UseCase11 wrong-method negative case) are skipped — those requests",
+          "// use per-request assertions only.",
+          "if (!pm.request.url.getPath().endsWith('/calculate') || pm.request.method !== 'POST') {",
+          "    return;",
+          "}",
+          "",
+          "var Ajv = require('ajv');",
+          "var ajv = new Ajv({ allErrors: true });",
+          "var schemaKey = pm.response.code === 200 ? \"successSchema\" : \"errorSchema\";",
+          "var schema = JSON.parse(pm.globals.get(schemaKey));",
+          "var validate = ajv.compile(schema);",
+          "",
+          "pm.test(\"Response matches JSON schema\", function () {",
+          "    var valid = validate(pm.response.json());",
+          "    pm.expect(valid, valid ? '' : ajv.errorsText(validate.errors)).to.be.true;",
+          "});"
+        ]
+      }
+    }
+  ],
+  "item": [
+    {
+      "name": "HealthCheck",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"status code is 200\", function () {",
+              "    pm.response.to.have.status(200);",
+              "});",
+              "",
+              "pm.test(\"Response has data field\", function () {",
+              "    var responseJSON = pm.response.json();",
+              "    pm.expect(responseJSON).to.have.property('data');",
+              "    pm.expect(responseJSON.data).to.be.a('string');",
+              "    pm.expect(responseJSON.data.length).to.be.above(0);",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{baseUrl}}/",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            ""
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "UseCase01",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"status code is 200\", function () {",
+              "    pm.response.to.have.status(200);",
+              "});",
+              "",
+              "pm.test(\"Response has correct airports\", function () {",
+              "    var responseJSON = pm.response.json();",
+              "    pm.expect(responseJSON[0]).to.equal(\"SFO\");",
+              "    pm.expect(responseJSON[1]).to.equal(\"EWR\");",
+              "});",
+              "",
+              "pm.test(\"Content-Type is application/json\", function () {",
+              "    pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "[[\"SFO\", \"EWR\"]]",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/calculate",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "calculate"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "UseCase02",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"status code is 200\", function () {",
+              "    pm.response.to.have.status(200);",
+              "});",
+              "",
+              "pm.test(\"Response has correct airports\", function () {",
+              "    var responseJSON = pm.response.json();",
+              "    pm.expect(responseJSON[0]).to.equal(\"SFO\");",
+              "    pm.expect(responseJSON[1]).to.equal(\"EWR\");",
+              "});",
+              "",
+              "pm.test(\"Content-Type is application/json\", function () {",
+              "    pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "[[\"ATL\", \"EWR\"], [\"SFO\", \"ATL\"]]",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/calculate",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "calculate"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "UseCase03",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"status code is 200\", function () {",
+              "    pm.response.to.have.status(200);",
+              "});",
+              "",
+              "pm.test(\"Response has correct airports\", function () {",
+              "    var responseJSON = pm.response.json();",
+              "    pm.expect(responseJSON[0]).to.equal(\"SFO\");",
+              "    pm.expect(responseJSON[1]).to.equal(\"EWR\");",
+              "});",
+              "",
+              "pm.test(\"Content-Type is application/json\", function () {",
+              "    pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "[[\"IND\", \"EWR\"], [\"SFO\", \"ATL\"], [\"GSO\", \"IND\"], [\"ATL\", \"GSO\"]]",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/calculate",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "calculate"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "UseCase04_EmptyBody",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"status code is 400\", function () {",
+              "    pm.response.to.have.status(400);",
+              "});",
+              "",
+              "pm.test(\"Error mentions empty segments\", function () {",
+              "    var responseJSON = pm.response.json();",
+              "    pm.expect(responseJSON.Error).to.include(\"empty\");",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "[]",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/calculate",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "calculate"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "UseCase05_MalformedJSON",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"status code is 400\", function () {",
+              "    pm.response.to.have.status(400);",
+              "});",
+              "",
+              "pm.test(\"Error mentions parsing\", function () {",
+              "    var responseJSON = pm.response.json();",
+              "    pm.expect(responseJSON.Error).to.include(\"parse\");",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "not valid json",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/calculate",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "calculate"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "UseCase06_IncompleteSegment",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"status code is 400\", function () {",
+              "    pm.response.to.have.status(400);",
+              "});",
+              "",
+              "pm.test(\"Error mentions source and destination\", function () {",
+              "    var responseJSON = pm.response.json();",
+              "    pm.expect(responseJSON.Error).to.include(\"source and destination\");",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "[[\"SFO\"]]",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/calculate",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "calculate"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "UseCase07_ExtraItemsInSegmentIgnored",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"status code is 200\", function () {",
+              "    pm.response.to.have.status(200);",
+              "});",
+              "",
+              "pm.test(\"Only first two elements of segment are used\", function () {",
+              "    var responseJSON = pm.response.json();",
+              "    pm.expect(responseJSON[0]).to.equal(\"SFO\");",
+              "    pm.expect(responseJSON[1]).to.equal(\"EWR\");",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "[[\"SFO\", \"EWR\", \"JFK\"]]",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/calculate",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "calculate"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "UseCase08_TenSegmentChain",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"status code is 200\", function () {",
+              "    pm.response.to.have.status(200);",
+              "});",
+              "",
+              "pm.test(\"Ten-segment scrambled chain resolves LAX to SFO\", function () {",
+              "    var responseJSON = pm.response.json();",
+              "    pm.expect(responseJSON[0]).to.equal(\"LAX\");",
+              "    pm.expect(responseJSON[1]).to.equal(\"SFO\");",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "[[\"ORD\",\"ATL\"],[\"LAX\",\"PHX\"],[\"JFK\",\"EWR\"],[\"BOS\",\"JFK\"],[\"PHX\",\"DEN\"],[\"EWR\",\"SEA\"],[\"DEN\",\"ORD\"],[\"ATL\",\"MIA\"],[\"SEA\",\"SFO\"],[\"MIA\",\"BOS\"]]",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/calculate",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "calculate"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "UseCase09_ObjectRoot",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"status code is 400\", function () {",
+              "    pm.response.to.have.status(400);",
+              "});",
+              "",
+              "pm.test(\"Error mentions parsing\", function () {",
+              "    var responseJSON = pm.response.json();",
+              "    pm.expect(responseJSON.Error).to.include(\"parse\");",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\"foo\":\"bar\"}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/calculate",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "calculate"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "UseCase10_SecondSegmentIncomplete",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"status code is 400\", function () {",
+              "    pm.response.to.have.status(400);",
+              "});",
+              "",
+              "pm.test(\"Error mentions source and destination\", function () {",
+              "    var responseJSON = pm.response.json();",
+              "    pm.expect(responseJSON.Error).to.include(\"source and destination\");",
+              "});",
+              "",
+              "pm.test(\"Error Index points at offending segment\", function () {",
+              "    var responseJSON = pm.response.json();",
+              "    pm.expect(responseJSON.Index).to.equal(1);",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "[[\"SFO\",\"EWR\"],[\"JFK\"]]",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/calculate",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "calculate"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "HealthCheck_SecurityHeaders",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"status code is 200\", function () {",
+              "    pm.response.to.have.status(200);",
+              "});",
+              "",
+              "pm.test(\"X-Frame-Options is DENY\", function () {",
+              "    pm.expect(pm.response.headers.get('X-Frame-Options')).to.equal('DENY');",
+              "});",
+              "",
+              "pm.test(\"X-XSS-Protection is set\", function () {",
+              "    pm.expect(pm.response.headers.get('X-XSS-Protection')).to.equal('1; mode=block');",
+              "});",
+              "",
+              "pm.test(\"X-Content-Type-Options is nosniff\", function () {",
+              "    pm.expect(pm.response.headers.get('X-Content-Type-Options')).to.equal('nosniff');",
+              "});",
+              "",
+              "pm.test(\"Referrer-Policy is strict-origin-when-cross-origin\", function () {",
+              "    pm.expect(pm.response.headers.get('Referrer-Policy')).to.equal('strict-origin-when-cross-origin');",
+              "});",
+              "",
+              "pm.test(\"Cross-Origin-Resource-Policy is same-origin\", function () {",
+              "    pm.expect(pm.response.headers.get('Cross-Origin-Resource-Policy')).to.equal('same-origin');",
+              "});",
+              "",
+              "pm.test(\"Cache-Control is no-store\", function () {",
+              "    pm.expect(pm.response.headers.get('Cache-Control')).to.equal('no-store');",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{baseUrl}}/",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            ""
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "HealthCheck_CORS",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"status code is 200\", function () {",
+              "    pm.response.to.have.status(200);",
+              "});",
+              "",
+              "pm.test(\"Access-Control-Allow-Origin echoes wildcard\", function () {",
+              "    // Server defaults CORS_ORIGIN to '*' when unset; Echo's CORSWithConfig",
+              "    // reflects that in Access-Control-Allow-Origin.",
+              "    pm.expect(pm.response.headers.get('Access-Control-Allow-Origin')).to.equal('*');",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Origin",
+            "value": "https://example.com"
+          }
+        ],
+        "url": {
+          "raw": "{{baseUrl}}/",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            ""
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Swagger_UI",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"status code is 200\", function () {",
+              "    pm.response.to.have.status(200);",
+              "});",
+              "",
+              "pm.test(\"Content-Type is text/html\", function () {",
+              "    pm.expect(pm.response.headers.get('Content-Type')).to.include('text/html');",
+              "});",
+              "",
+              "pm.test(\"Response body references swagger-ui\", function () {",
+              "    pm.expect(pm.response.text()).to.include('swagger-ui');",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{baseUrl}}/swagger/index.html",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "swagger",
+            "index.html"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "UseCase11_WrongMethod",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"status code is 405 Method Not Allowed\", function () {",
+              "    pm.response.to.have.status(405);",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{baseUrl}}/calculate",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "calculate"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "UseCase12_UnknownRoute",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"status code is 404 Not Found\", function () {",
+              "    pm.response.to.have.status(404);",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{baseUrl}}/does-not-exist",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "does-not-exist"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "UseCase13_LargeChain",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "// Build a 100-segment chain AAA -> AAB -> ... -> ADW, then shuffle",
+              "// the segments so the server must reconstruct the order.",
+              "function codeFor(i) {",
+              "    return 'A' + String.fromCharCode(65 + Math.floor(i / 26)) + String.fromCharCode(65 + (i % 26));",
+              "}",
+              "var segments = [];",
+              "for (var i = 0; i < 100; i++) {",
+              "    segments.push([codeFor(i), codeFor(i + 1)]);",
+              "}",
+              "for (var j = segments.length - 1; j > 0; j--) {",
+              "    var k = Math.floor(Math.random() * (j + 1));",
+              "    var tmp = segments[j]; segments[j] = segments[k]; segments[k] = tmp;",
+              "}",
+              "pm.variables.set('largeChainBody', JSON.stringify(segments));",
+              "pm.variables.set('largeChainStart', codeFor(0));",
+              "pm.variables.set('largeChainEnd', codeFor(100));"
+            ]
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"status code is 200\", function () {",
+              "    pm.response.to.have.status(200);",
+              "});",
+              "",
+              "pm.test(\"Response reconstructs the full 100-segment chain\", function () {",
+              "    var responseJSON = pm.response.json();",
+              "    pm.expect(responseJSON[0]).to.equal(pm.variables.get('largeChainStart'));",
+              "    pm.expect(responseJSON[1]).to.equal(pm.variables.get('largeChainEnd'));",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{{largeChainBody}}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/calculate",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "calculate"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "UseCase14_WrongContentType",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"status code is 400 Bad Request\", function () {",
+              "    pm.response.to.have.status(400);",
+              "});",
+              "",
+              "pm.test(\"Error message indicates parse failure\", function () {",
+              "    var responseJSON = pm.response.json();",
+              "    pm.expect(responseJSON).to.have.property('Error');",
+              "    pm.expect(responseJSON.Error).to.include(\"parse\");",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "text/plain"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "[[\"SFO\", \"EWR\"]]"
+        },
+        "url": {
+          "raw": "{{baseUrl}}/calculate",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "calculate"
+          ]
+        }
+      },
+      "response": []
+    }
+  ],
+  "variable": [
+    {
+      "key": "baseUrl",
+      "value": "http://localhost:8080",
+      "type": "string"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Fixes one HIGH and a batch of MEDIUM/LOW findings from `/project-review`, `/harden-image-pipeline`, and `/test-coverage-analysis`. Also bundles the orphaned `chore: add benchmark snapshot 2026-05-03` commit (from a prior session that didn't push).

## What changed

**Security (HIGH):**
- Makefile `ci-run`: replaced `act --secret KEY=$VAR` (leaks token via `ps -ef` / `/proc/<pid>/cmdline`) with bash-array env-only `--secret KEY` form. Per-job act loop with `--pull=false` (containerd race avoidance) and ephemeral artifact-server port + `mktemp -d` path so parallel sibling-repo runs don't collide.
- New `lint-scripts-exec` target: blocks `0644` shell scripts (subagent-write trap) before they reach CI.

**E2E ephemeral port (parallel-run resilience):**
- `scripts/pick-port.sh` (new): kernel-ephemeral port allocator (Python primary, `ss` fallback).
- `Makefile` e2e: allocates port, exports `SERVER_PORT`, passes `baseUrl=http://localhost:$PORT` to Newman via `--env-var`.
- `test/FlightPath.postman_collection.json`: `{{baseUrl}}` collection variable + URL rewrite (18 requests).

**Integration test parity with Newman E2E (+6 tests):**
- `internal/app/app_integration_test.go`: `TestCalculateEmptyBody`, `TestCalculateObjectRoot`, `TestCalculateExtraItemsIgnored`, `TestCalculate100SegmentChain`, `TestSwaggerIndexServesHTML`, plus `X-XSS-Protection` added to `wantHeaders` map. Closes the gap where Newman caught regressions before integration could.

**CI workflow hygiene:**
- `ci.yml`: image path → canonical `ghcr.io/${{ github.repository }}` (rename/fork-portable); Newman step renamed; `# renovate:` comment on inline `CST_VERSION`; new `renovate.json` `customManagers` regex tracks workflow inline `VAR=` pins.
- `auto-merge.yml`: workflow-level permissions scoped to the job; job key `enable` → `auto-merge` for grep-symmetry.

**Documentation:**
- `docs/ARCHITECTURE.md`: CORS preflight + security-headers sequence diagram (rounds out the runtime view).
- `README.md`: tightened description; `UpdateLayoutConfig($c4ShapeInRow="2")` on the C4Context hero.

**Also bundled:** `chore: add benchmark snapshot 2026-05-03` (orphaned commit, restoring continuity with the existing `benchmarks/` history).

## Test plan

- [x] `make ci` passes locally (static-check + 21 integration tests + 80% coverage + fuzz 30s + deps-prune-check)
- [x] `make e2e` — 18 requests, 56 assertions (was 53), 0 failed, with ephemeral port
- [x] `make mermaid-lint` — README + ARCHITECTURE.md both render cleanly
- [x] `actionlint` clean on all 5 workflows
- [x] `renovate.json` valid; new custom manager regex matches workflow-inline pattern
- [ ] CI passes with no new diagnostics