### PR TITLE
fix(deps): bump Go 1.26.2 → 1.26.3 to clear stdlib CVEs

### DIFF
--- a/.claude/skills/environment/SKILL.md
+++ b/.claude/skills/environment/SKILL.md
@@ -10,7 +10,7 @@ description: >
 
 ## Go (via mise)
 
-Pinned in `.mise.toml` at repo root: `go = "1.26.2"`. Activated automatically via shell hook (`eval "$(mise activate bash)"` or zsh/fish equivalent in `~/.zshrc`). `make deps` installs the pinned Go through mise; CI uses `actions/setup-go` with `go-version-file: 'go.mod'`.
+Pinned in `.mise.toml` at repo root: `go = "1.26.3"`. Activated automatically via shell hook (`eval "$(mise activate bash)"` or zsh/fish equivalent in `~/.zshrc`). `make deps` installs the pinned Go through mise; CI uses `actions/setup-go` with `go-version-file: 'go.mod'`.
 
 ## Node.js (via nvm)
 

--- a/.claude/skills/troubleshooting/SKILL.md
+++ b/.claude/skills/troubleshooting/SKILL.md
@@ -42,7 +42,7 @@ make run
 ## Build Fails
 
 ```bash
-go version                # Must match go.mod (1.26.2)
+go version                # Must match go.mod (1.26.3)
 go mod tidy && make build # Clean up and retry
 go clean -cache           # Nuclear option
 ```

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,6 +1,6 @@
 [tools]
 # Language toolchains (Go version mirrors go.mod; node mirrors .nvmrc)
-go = "1.26.2"
+go = "1.26.3"
 node = "24"
 
 # Static analysis + security tooling — version-of-truth for local + CI.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 **flight-path** is a Go REST API microservice that calculates flight paths from unordered flight segments. Given a list of [source, destination] pairs, it determines the complete path (starting airport to ending airport).
 
-- **Language**: Go 1.26.2 (via mise, optional — system Go works too)
+- **Language**: Go 1.26.3 (via mise, optional — system Go works too)
 - **Framework**: Echo v5 (v5.1.0)
 - **Docs**: Swagger/Swaggo (auto-generated)
 - **Version**: See `pkg/api/version.txt`
@@ -291,7 +291,7 @@ Prune workflow (`cleanup-runs.yml`) runs weekly (Sundays at 00:00 UTC) to delete
 - **Tool not found** (`swag`, `golangci-lint`, etc.): Run `make deps` and ensure `$(go env GOPATH)/bin` is in PATH
 - **Swagger UI shows stale docs**: Run `make api-docs`, restart server, hard-refresh browser
 - **Tests fail after changes**: Run `go test -v ./...` for verbose output; `go clean -testcache` to clear cache
-- **Build fails**: Check `go version` matches go.mod (1.26.2); if mismatch, use mise (`mise install`) or reinstall, then run `go mod tidy` and `make build`
+- **Build fails**: Check `go version` matches go.mod (1.26.3); if mismatch, use mise (`mise install`) or reinstall, then run `go mod tidy` and `make build`
 - **E2E tests fail**: Ensure server is running first (`make run &`, wait a few seconds, then `make e2e`)
 
 ## Skills
@@ -327,7 +327,7 @@ Items identified by upgrade analysis. Review periodically, act when conditions c
 
 ## Environment
 
-- Go 1.26.2 via mise (reads `.mise.toml`); install with `curl -fsSL https://mise.jdx.dev/install.sh | bash`
+- Go 1.26.3 via mise (reads `.mise.toml`); install with `curl -fsSL https://mise.jdx.dev/install.sh | bash`
 - Node.js via mise (reads `.mise.toml` / `.nvmrc`); pnpm enabled via corepack
 - Quality/security tools (golangci-lint, gosec, govulncheck, gitleaks, actionlint, shellcheck, hadolint, trivy, act, goreleaser) are mise-managed and surface on `PATH` via `$HOME/.local/share/mise/shims` (exported by the Makefile alongside `$HOME/.local/bin` for the mise installer itself)
 - Environment variables loaded from `.env` (`SERVER_PORT=8080`)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1@sha256:4a43a54dd1fedceb30ba47e76cfcf2b47304f4161c0caeac2db1c61804ea3c91
 
 # build
-FROM --platform=$BUILDPLATFORM golang:1.26-alpine@sha256:c2a1f7b2095d046ae14b286b18413a05bb82c9bca9b25fe7ff5efef0f0826166 AS build
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS build
 WORKDIR /app
 COPY go.mod go.sum ./
 ARG GOMODCACHE=/go/pkg/mod

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ See [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md) for Container, request-flow s
 
 | Component | Technology | Rationale |
 |-----------|------------|-----------|
-| Language | Go 1.26.2 (from `go.mod`) | Statically compiled binary, strong stdlib HTTP, goroutine concurrency |
+| Language | Go 1.26.3 (from `go.mod`) | Statically compiled binary, strong stdlib HTTP, goroutine concurrency |
 | Framework | Echo v5.1.0 | Lightweight router with built-in JSON binding, middleware stack, Swagger integration |
 | API Docs | Swagger (swaggo/swag v2) | Auto-generated OpenAPI spec from Go annotations |
 | Testing | go test (unit, bench, fuzz), Newman/Postman (E2E) | Table-driven unit tests + black-box API tests against the built binary |
@@ -47,7 +47,7 @@ make run       # build and start the server
 
 | Tool | Version | Purpose |
 |------|---------|---------|
-| [Go](https://go.dev/dl/) | 1.26.2 (see `go.mod`) | Language runtime and compiler |
+| [Go](https://go.dev/dl/) | 1.26.3 (see `go.mod`) | Language runtime and compiler |
 | [mise](https://mise.jdx.dev/) | latest | Toolchain manager — reads `.mise.toml` to install pinned Go + Node |
 | [GNU Make](https://www.gnu.org/software/make/) | 3.81+ | Build orchestration |
 | [Git](https://git-scm.com/) | 2.0+ | Version control |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -17,7 +17,7 @@ C4Container
     Person(client, "API Client", "cURL, Postman, Newman, browser")
 
     System_Boundary(api, "Flight Path API") {
-        Container(server, "flight-path server", "Go 1.26.2, Echo v5.1.0", "Single static binary. Serves POST /calculate, GET /, and GET /swagger/* (embedded Swagger UI via swaggo/echo-swagger v2.0.1). Middleware stack: Logger, Recover, CORS, Secure, Cache-Control, Gzip, RequestID, BodyLimit 1 MiB.")
+        Container(server, "flight-path server", "Go 1.26.3, Echo v5.1.0", "Single static binary. Serves POST /calculate, GET /, and GET /swagger/* (embedded Swagger UI via swaggo/echo-swagger v2.0.1). Middleware stack: Logger, Recover, CORS, Secure, Cache-Control, Gzip, RequestID, BodyLimit 1 MiB.")
     }
 
     Rel(client, server, "POST /calculate, GET /, GET /swagger/*", "HTTPS / JSON")

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/AndriyKalashnykov/flight-path
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/labstack/echo/v5 v5.1.0

--- a/specs/BUILD.md
+++ b/specs/BUILD.md
@@ -6,7 +6,7 @@ Go and Node are provisioned by [mise](https://mise.jdx.dev/) from `.mise.toml` (
 
 | Tool | Source of truth | Purpose |
 |---|---|---|
-| Go | `go.mod` + `.mise.toml` | Language runtime (currently 1.26.2) |
+| Go | `go.mod` + `.mise.toml` | Language runtime (currently 1.26.3) |
 | Node.js | `.nvmrc` + `.mise.toml` | Newman E2E runner (currently major 24) |
 | golangci-lint | `.mise.toml` | Meta-linter (configured via `.golangci.yml`) |
 | gosec | `.mise.toml` (aqua:securego/gosec) | Security scanner |


### PR DESCRIPTION
## Summary

Bumps Go 1.26.2 → 1.26.3 in `go.mod` and `.mise.toml` to clear 5 stdlib vulnerabilities flagged by `govulncheck`.

## Root Cause

CI's `static-check` job has been failing on `main` since Go 1.26.3 was published, because `make vulncheck` blocks on these (all fixed in 1.26.3):

| ID | Component | Fix |
|---|---|---|
| GO-2026-4982 | `html/template` (XSS via meta content URL escape bypass) | 1.26.3 |
| GO-2026-4980 | `html/template` (escaper bypass → XSS) | 1.26.3 |
| GO-2026-4976 | `net/http/httputil` (ReverseProxy query param overflow) | 1.26.3 |
| GO-2026-4971 | `net` (Dial/LookupPort panic on Windows NUL) | 1.26.3 |
| GO-2026-4918 | `net/http` (HTTP/2 SETTINGS_MAX_FRAME_SIZE infinite loop) | 1.26.3 |

This blocked every PR landing on `main`, including the unrelated Renovate PR #236 (claude-code-action bump).

## Changes

- `go.mod`: `go 1.26.2` → `go 1.26.3`
- `.mise.toml`: `go = "1.26.2"` → `go = "1.26.3"`
- Doc references (CLAUDE.md, README.md, docs/ARCHITECTURE.md, specs/BUILD.md, two skill SKILL.md files) updated to match

No code changes; binary still builds clean.

## Test plan

- [x] `make vulncheck` — `No vulnerabilities found.`
- [x] `make static-check` — passes
- [x] `make test` — all tests + fuzz seeds pass
- [x] `make build` — produces server binary
- [ ] CI green on PR
- [ ] PR #236 rebases automatically once this merges