### PR TITLE
docs: backfill new middleware + env vars across specs and .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,20 @@
 
 # HTTP listen port. Code reads via SERVER_PORT in internal/app/app.go.
 SERVER_PORT=8080
+
+# Optional overrides — defaults in the binary cover dev/CI; set explicitly
+# only when the deployment topology demands it.
+
+# Bind / introspect host. Used by scripts/wait-for-server.sh and the Dockerfile
+# HEALTHCHECK; the binary itself listens on all interfaces. Default: localhost
+# (scripts) / 127.0.0.1 (container HEALTHCHECK).
+# SERVER_HOST=localhost
+
+# CORS allowed-origin list. Comma-separated for multi-origin allowlists.
+# Default: "*" (echoes any Origin header) — tighten this in production.
+# CORS_ORIGIN=https://app.example,https://admin.example
+
+# Rate limiter (per-IP, in-memory store; expires after 3 minutes idle).
+# Defaults: 100 req/s sustained, 200-request burst.
+# RATE_LIMIT_PER_SEC=100
+# RATE_LIMIT_BURST=200

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -17,7 +17,7 @@ C4Container
     Person(client, "API Client", "cURL, Postman, Newman, browser")
 
     System_Boundary(api, "Flight Path API") {
-        Container(server, "flight-path server", "Go 1.26.3, Echo v5.1.0", "Single static binary. Serves POST /calculate, GET /, and GET /swagger/* (embedded Swagger UI via swaggo/echo-swagger v2.0.1). Middleware stack: Logger, Recover, CORS, Secure, Cache-Control, Gzip, RequestID, BodyLimit 1 MiB.")
+        Container(server, "flight-path server", "Go 1.26.3, Echo v5.1.0", "Single static binary. Serves POST /calculate, GET /, and GET /swagger/* (embedded Swagger UI via swaggo/echo-swagger v2.0.1). Middleware: RequestID, Logger, Recover, BodyLimit 1 MiB, Gzip, RateLimiter (100/s, burst 200), CORS (multi-origin via CORS_ORIGIN), Secure headers, Cache-Control no-store.")
     }
 
     Rel(client, server, "POST /calculate, GET /, GET /swagger/*", "HTTPS / JSON")

--- a/specs/API.md
+++ b/specs/API.md
@@ -4,11 +4,11 @@
 
 | Property | Value |
 |---|---|
-| Base URL | `http://localhost:{SERVER_PORT}` |
+| Base URL | `http://{SERVER_HOST}:{SERVER_PORT}` (defaults: `localhost:8080`; both env-overridable) |
 | Default Port | `8080` (from `.env`) |
 | Protocol | HTTP |
 | Content-Type | `application/json` |
-| CORS | All origins allowed (`*`) |
+| CORS | Driven by `CORS_ORIGIN` env (default `*`; comma-separated list supported for multi-origin allowlists) |
 
 ## Endpoints
 
@@ -84,16 +84,20 @@ Swagger UI for interactive API documentation (auto-generated OpenAPI 2.0 spec).
 | Version | 1.0 |
 | License | Apache 2.0 |
 | Contact | Andriy Kalashnykov |
-| Host | localhost:8080 |
+| Host | inferred at request time from the URL the spec was loaded from (no `host` field in the OpenAPI spec) |
 | BasePath | / |
-| Schemes | http |
+| Schemes | inferred at request time (no `schemes` field in the OpenAPI spec) |
 
 ## Middleware Stack
 
 Applied in `internal/app/app.go` in this order:
 
-1. **RequestLogger** — logs incoming requests
-2. **Recover** — recovers from panics, returns 500
-3. **CORS** — `Access-Control-Allow-Origin` from `CORS_ORIGIN` env (defaults to `*`)
-4. **Secure** — sets `X-XSS-Protection: 1; mode=block`, `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: strict-origin-when-cross-origin`
-5. **Cache-Control / CORP** (custom) — adds `Cache-Control: no-store` and `Cross-Origin-Resource-Policy: same-origin` to every response
+1. **RequestID** — assigns each request a unique `X-Request-Id` header
+2. **RequestLogger** — logs incoming requests (structured JSON, includes the request id)
+3. **Recover** — recovers from panics, returns 500
+4. **BodyLimit** — caps request bodies at 1 MiB (`1 << 20` bytes); oversized requests return 413
+5. **Gzip** — content-encoding negotiation; gzip-encodes responses when the client sends `Accept-Encoding: gzip`
+6. **RateLimiter** (in-memory store) — 100 req/s sustained, 200-request burst per IP; oversize returns 429. Tunable via `RATE_LIMIT_PER_SEC` (float, default 100) and `RATE_LIMIT_BURST` (int, default 200)
+7. **CORS** — `Access-Control-Allow-Origin` derived from `CORS_ORIGIN` env. Empty / unset defaults to `*`. Supports a comma-separated list for multi-origin allowlists (e.g., `CORS_ORIGIN="https://app.example, https://admin.example"`)
+8. **Secure** — sets `X-XSS-Protection: 1; mode=block`, `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: strict-origin-when-cross-origin`
+9. **Cache-Control / CORP** (custom) — adds `Cache-Control: no-store` and `Cross-Origin-Resource-Policy: same-origin` to every response

--- a/specs/ARCHITECTURE.md
+++ b/specs/ARCHITECTURE.md
@@ -102,23 +102,29 @@ Routes in `internal/routes/` receive `*handlers.Handler` and wire methods.
 
 Registered in `internal/app/app.go` in this order:
 
-1. `RequestLogger` — request access log
-2. `Recover` — panic → 500
-3. `CORS` — `CORS_ORIGIN` env var (defaults to `*`)
-4. `Secure` — XSS, nosniff, X-Frame-Options: DENY, Referrer-Policy: strict-origin-when-cross-origin
-5. Custom headers — `Cache-Control: no-store`, `Cross-Origin-Resource-Policy: same-origin`
+1. `RequestID` — per-request `X-Request-Id` header
+2. `RequestLogger` — structured JSON access log (includes the request id)
+3. `Recover` — panic → 500
+4. `BodyLimit(1 << 20)` — caps requests at 1 MiB; oversize → 413
+5. `Gzip` — gzip-encodes responses when the client sends `Accept-Encoding: gzip`
+6. `RateLimiter` (in-memory store) — 100 req/s sustained, 200-burst per IP; oversize → 429
+7. `CORS` — `CORS_ORIGIN` env var (defaults to `*`; comma-separated list supported for multi-origin allowlists)
+8. `Secure` — XSS, nosniff, X-Frame-Options: DENY, Referrer-Policy: strict-origin-when-cross-origin
+9. Custom headers — `Cache-Control: no-store`, `Cross-Origin-Resource-Policy: same-origin`
 
 ### Configuration
 
-- `.env` loaded via `godotenv`, overridable with `--env-file` flag
+- `.env` loaded via the in-house `internal/envfile` package, overridable with the `--env-file` flag
 - `SERVER_PORT` — server port (default `8080`)
-- `CORS_ORIGIN` — single allowed origin for CORS (default `*`)
+- `SERVER_HOST` — bind / introspect host (default `localhost` in scripts, `127.0.0.1` in the container HEALTHCHECK)
+- `CORS_ORIGIN` — single origin or comma-separated allowlist (default `*`)
+- `RATE_LIMIT_PER_SEC` — sustained-rate quota for the in-memory rate limiter, float (default `100`)
+- `RATE_LIMIT_BURST` — burst quota for the in-memory rate limiter, int (default `200`)
 
 ## Dependencies
 
 | Package | Purpose |
 |---|---|
 | `echo/v5` | HTTP framework |
-| `godotenv` | Load `.env` files |
 | `swaggo/echo-swagger/v2` | Serve Swagger UI |
 | `swaggo/swag` | Generate OpenAPI spec from annotations |


### PR DESCRIPTION
## Summary

Audit follow-up after PRs #237 / #238 / #239: the new middleware (BodyLimit, Gzip, RequestID, RateLimiter, multi-origin CORS) and the godotenv → `internal/envfile` migration landed in code but several spec/architecture/env-example surfaces still described the pre-#238 stack. This brings the docs in line with the actual code.

## Files changed

- **`docs/ARCHITECTURE.md`** — C4 Container description: middleware list now reflects the actual stack (RequestID + BodyLimit + Gzip + RateLimiter added; ordering matches `internal/app/app.go`).
- **`specs/API.md`** — Middleware Stack section expanded; Base URL row now `{SERVER_HOST}:{SERVER_PORT}` (both env-overridable, defaults `localhost:8080`); CORS row mentions multi-origin support; Host/Schemes rows correctly state these are inferred at request time (Swagger `@host` / `@schemes` annotations were removed in #239).
- **`specs/ARCHITECTURE.md`** — Middleware stack and Configuration env-var list updated; `godotenv` dropped from the direct-dependencies table (replaced by `internal/envfile`).
- **`.env.example`** — Exposes the new env-overridable knobs (`SERVER_HOST`, `CORS_ORIGIN`, `RATE_LIMIT_PER_SEC`, `RATE_LIMIT_BURST`) as commented examples so operators know they exist without forcing a value.

## Test plan

- [x] `make mermaid-lint` — both Mermaid blocks (README + docs/ARCHITECTURE.md) render clean
- [ ] CI green on PR