### PR TITLE
fix: bump Go toolchain to 1.26.4 to clear stdlib CVEs (GO-2026-5037, GO-2026-5039)

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,6 +1,6 @@
 [tools]
 # Language toolchains (Go version mirrors go.mod; node mirrors .nvmrc)
-go = "1.26.3"
+go = "1.26.4"
 node = "24"
 
 # Static analysis + security tooling — version-of-truth for local + CI.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1@sha256:4a43a54dd1fedceb30ba47e76cfcf2b47304f4161c0caeac2db1c61804ea3c91
 
 # build
-FROM --platform=$BUILDPLATFORM golang:1.26-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS build
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f AS build
 WORKDIR /app
 COPY go.mod go.sum ./
 ARG GOMODCACHE=/go/pkg/mod

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/AndriyKalashnykov/flight-path
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/labstack/echo/v5 v5.1.1


### PR DESCRIPTION
## Root cause

PR #260 (a GitHub Actions SHA bump) fails `static-check` — but **not because of the PR**. The failing step is `govulncheck`, which flags two freshly-disclosed Go **standard-library** vulnerabilities reachable from this service, both fixed in **go1.26.4** while `main` is pinned to **go1.26.3**:

| Vuln | Package | Reachable via | Fixed in |
|------|---------|---------------|----------|
| [GO-2026-5039](https://pkg.go.dev/vuln/GO-2026-5039) | `net/textproto` | `echo.Echo.Start` → `ReadMIMEHeader` | go1.26.4 |
| [GO-2026-5037](https://pkg.go.dev/vuln/GO-2026-5037) | `crypto/x509` | TLS verify + `envfile.Load`→`fmt.Errorf` | go1.26.4 |

This is a `main`-level failure surfacing on every PR's `static-check` (the "in-flight PRs failing identically → diagnose `main`, not the PR" pattern), and a recurrence of the earlier Go 1.26.1→1.26.2 stdlib-vuln incident.

The correct fix is to bump the toolchain — **not** to waive govulncheck, since the findings are real and reachable.

## Change

Mirrors what Renovate's "Go toolchain" group does — bumps all three pins in one PR:

- `go.mod`: `go 1.26.3` → `go 1.26.4`
- `.mise.toml`: `go = "1.26.3"` → `"1.26.4"`
- `Dockerfile`: `golang:1.26-alpine` digest → `sha256:f23e8b…` (verified `go version` = go1.26.4), so the `docker` job's Trivy image scan doesn't ship a 1.26.3-stdlib binary

`go mod tidy` produced no dependency churn (only the `go` directive). Swagger regen is byte-identical.

## Verification (local, go1.26.4)

- `govulncheck ./...` → **No vulnerabilities found**
- `make static-check` → **passed** (govulncheck + trivy-fs + lint + gosec + …)
- `make build` → ok
- `make test` → PASS

## Follow-up

Once merged, Renovate auto-rebases #260; its `static-check` then passes on the same Go bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)