### PR TITLE
docs(skill): add Go-stdlib-CVE runbook to troubleshooting skill

### DIFF
--- a/.claude/skills/environment/SKILL.md
+++ b/.claude/skills/environment/SKILL.md
@@ -10,7 +10,7 @@ description: >
 
 ## Go (via mise)
 
-Pinned in `.mise.toml` at repo root: `go = "1.26.3"`. Activated automatically via shell hook (`eval "$(mise activate bash)"` or zsh/fish equivalent in `~/.zshrc`). `make deps` installs the pinned Go through mise; CI uses `actions/setup-go` with `go-version-file: 'go.mod'`.
+Pinned in `.mise.toml` at repo root: `go = "1.26.4"`. Activated automatically via shell hook (`eval "$(mise activate bash)"` or zsh/fish equivalent in `~/.zshrc`). `make deps` installs the pinned Go through mise; CI uses `actions/setup-go` with `go-version-file: 'go.mod'`.
 
 ## Node.js (via nvm)
 

--- a/.claude/skills/troubleshooting/SKILL.md
+++ b/.claude/skills/troubleshooting/SKILL.md
@@ -42,7 +42,7 @@ make run
 ## Build Fails
 
 ```bash
-go version                # Must match go.mod (1.26.3)
+go version                # Must match the `go` directive in go.mod
 go mod tidy && make build # Clean up and retry
 go clean -cache           # Nuclear option
 ```
@@ -50,6 +50,62 @@ go clean -cache           # Nuclear option
 - `make build` depends on `api-docs` (which depends on `deps`), then compiles
 - Ensure `GOFLAGS=-mod=mod` is set (Makefile sets this automatically)
 - Use `make check` for the full pre-commit chain: `lint sec vulncheck secrets test api-docs build`
+
+## `static-check` / `govulncheck` Fails on an Unrelated PR (Go stdlib CVE)
+
+**Symptom:** An open PR that touches no Go code — e.g. a Renovate GitHub Actions
+SHA bump — fails the `static-check` job at the `govulncheck` step. Multiple
+in-flight PRs fail identically.
+
+**Root cause:** `govulncheck` flags a Go **standard-library** vulnerability
+present in the pinned Go patch on `main`. The failure lives in `main`'s
+toolchain, not the PR diff, so it surfaces on *every* PR's `static-check`.
+This is the "N in-flight PRs failing identically → diagnose `main`, not the
+PRs" pattern. It recurs each time a Go patch ships stdlib security fixes.
+
+**Diagnose** — read the actual failing step, don't guess:
+```bash
+gh run view <run-id> --log-failed | grep -A4 'Vulnerability #'
+# Look for: "Standard library", "Found in: <pkg>@goX.Y.Z", "Fixed in: <pkg>@goX.Y.W"
+```
+
+**Fix (real fix — bump Go; NEVER waive a reachable stdlib CVE).** Bump the Go
+patch across all three pins in ONE change (mirrors Renovate's "Go toolchain"
+group so the managers stay consistent):
+
+| File | Line |
+|------|------|
+| `go.mod` | `go X.Y.W` |
+| `.mise.toml` | `go = "X.Y.W"` |
+| `Dockerfile` | `golang:1.26-alpine@sha256:<digest>` — refresh so the `docker` job's Trivy scan doesn't ship a binary built against the old stdlib |
+
+Get the new digest and confirm it is the fixed patch *before* editing:
+```bash
+docker buildx imagetools inspect golang:1.26-alpine --format '{{.Manifest.Digest}}'
+docker run --rm golang:1.26-alpine@<digest> go version   # MUST show the fixed patch goX.Y.W
+```
+
+Verify locally before pushing (this is the proof, not a hope):
+```bash
+mise install go@X.Y.W
+mise exec -- govulncheck ./...   # must report "No vulnerabilities found"
+make static-check                # the full gate that was failing
+make check-go-alignment          # go.mod and .mise.toml must agree
+```
+
+Then PR the fix to `main` (do NOT push onto the Renovate branch — it can
+auto-merge from under you). Renovate auto-rebases the in-flight PRs onto the
+fix and they go green.
+
+**Why Renovate didn't bump it first:** Go patches ship ~monthly and
+`govulncheck` flips red the instant a CVE is disclosed — faster than any
+Renovate schedule + CI + automerge cycle, so a manual bump-on-red is the
+correct fast path. Additionally, if past Go bumps were applied **manually**
+(as stdlib-CVE fires force), Renovate's gomod extraction diverges and the
+"Go toolchain" group stops firing. Tell: the Renovate Dependency Dashboard
+(issue #8) freezes at an old `go` version and lists deps the repo no longer
+has. To re-engage it, tick the rebase/refresh checkbox on the Dashboard to
+force a fresh extraction.
 
 ## Tests Fail
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 **flight-path** is a Go REST API microservice that calculates flight paths from unordered flight segments. Given a list of [source, destination] pairs, it determines the complete path (starting airport to ending airport).
 
-- **Language**: Go 1.26.3 (via mise, optional — system Go works too)
+- **Language**: Go 1.26.4 (via mise, optional — system Go works too)
 - **Framework**: Echo v5 (v5.1.1)
 - **Docs**: Swagger/Swaggo (auto-generated)
 - **Version**: See `pkg/api/version.txt`
@@ -301,7 +301,7 @@ Auto-merge workflow (`auto-merge.yml`) enables GitHub native auto-merge on Renov
 - **Tool not found** (`swag`, `golangci-lint`, etc.): Run `make deps` and ensure `$(go env GOPATH)/bin` is in PATH
 - **Swagger UI shows stale docs**: Run `make api-docs`, restart server, hard-refresh browser
 - **Tests fail after changes**: Run `go test -v ./...` for verbose output; `go clean -testcache` to clear cache
-- **Build fails**: Check `go version` matches go.mod (1.26.3); if mismatch, use mise (`mise install`) or reinstall, then run `go mod tidy` and `make build`
+- **Build fails**: Check `go version` matches the `go` directive in go.mod; if mismatch, use mise (`mise install`) or reinstall, then run `go mod tidy` and `make build`
 - **E2E tests fail**: Ensure server is running first (`make run &`, wait a few seconds, then `make e2e`)
 
 ## Skills
@@ -334,7 +334,7 @@ Items identified by upgrade analysis. Review periodically, act when conditions c
 
 ## Environment
 
-- Go 1.26.3 via mise (reads `.mise.toml`); install with `curl -fsSL https://mise.jdx.dev/install.sh | bash`
+- Go 1.26.4 via mise (reads `.mise.toml`); install with `curl -fsSL https://mise.jdx.dev/install.sh | bash`
 - Node.js via mise (reads `.mise.toml` / `.nvmrc`); pnpm enabled via corepack
 - Quality/security tools (golangci-lint, gosec, govulncheck, gitleaks, actionlint, shellcheck, hadolint, trivy, act, goreleaser) are mise-managed and surface on `PATH` via `$HOME/.local/share/mise/shims` (exported by the Makefile alongside `$HOME/.local/bin` for the mise installer itself)
 - Environment variables loaded from `.env` (`SERVER_PORT=8080`)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ See [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md) for Container, request-flow s
 
 | Component | Technology | Rationale |
 |-----------|------------|-----------|
-| Language | Go 1.26.3 (from `go.mod`) | Statically compiled binary, strong stdlib HTTP, goroutine concurrency |
+| Language | Go 1.26.4 (from `go.mod`) | Statically compiled binary, strong stdlib HTTP, goroutine concurrency |
 | Framework | Echo v5.1.1 | Lightweight router with built-in JSON binding, middleware stack, Swagger integration |
 | API Docs | Swagger (swaggo/swag v2) | Auto-generated OpenAPI spec from Go annotations |
 | Testing | go test (unit, bench, fuzz), Newman/Postman (E2E) | Table-driven unit tests + black-box API tests against the built binary |
@@ -49,7 +49,7 @@ make run       # build and start the server
 
 | Tool | Version | Purpose |
 |------|---------|---------|
-| [Go](https://go.dev/dl/) | 1.26.3 (see `go.mod`) | Language runtime and compiler |
+| [Go](https://go.dev/dl/) | 1.26.4 (see `go.mod`) | Language runtime and compiler |
 | [mise](https://mise.jdx.dev/) | latest | Toolchain manager — reads `.mise.toml` to install pinned Go + Node |
 | [GNU Make](https://www.gnu.org/software/make/) | 3.81+ | Build orchestration |
 | [Git](https://git-scm.com/) | 2.0+ | Version control |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -17,7 +17,7 @@ C4Container
     Person(client, "API Client", "cURL, Postman, Newman, browser")
 
     System_Boundary(api, "Flight Path API") {
-        Container(server, "flight-path server", "Go 1.26.3, Echo v5.1.1", "Single static binary. Serves POST /calculate, GET /, and GET /swagger/* (embedded Swagger UI via swaggo/echo-swagger v2.0.1). Middleware: RequestID, Logger, Recover, BodyLimit 1 MiB, Gzip, RateLimiter (100/s, burst 200), CORS (multi-origin via CORS_ORIGIN), Secure headers, Cache-Control no-store.")
+        Container(server, "flight-path server", "Go 1.26.4, Echo v5.1.1", "Single static binary. Serves POST /calculate, GET /, and GET /swagger/* (embedded Swagger UI via swaggo/echo-swagger v2.0.1). Middleware: RequestID, Logger, Recover, BodyLimit 1 MiB, Gzip, RateLimiter (100/s, burst 200), CORS (multi-origin via CORS_ORIGIN), Secure headers, Cache-Control no-store.")
     }
 
     Rel(client, server, "POST /calculate, GET /, GET /swagger/*", "HTTPS / JSON")

--- a/specs/BUILD.md
+++ b/specs/BUILD.md
@@ -6,7 +6,7 @@ Go and Node are provisioned by [mise](https://mise.jdx.dev/) from `.mise.toml` (
 
 | Tool | Source of truth | Purpose |
 |---|---|---|
-| Go | `go.mod` + `.mise.toml` | Language runtime (currently 1.26.3) |
+| Go | `go.mod` + `.mise.toml` | Language runtime (currently 1.26.4) |
 | Node.js | `.nvmrc` + `.mise.toml` | Newman E2E runner (currently major 24) |
 | golangci-lint | `.mise.toml` | Meta-linter (configured via `.golangci.yml`) |
 | gosec | `.mise.toml` (aqua:securego/gosec) | Security scanner |


### PR DESCRIPTION
Extracts the lesson from the PR #261 session into the project `troubleshooting` skill.

**What & why:** When `static-check` fails at `govulncheck` on a PR that touches no Go code (e.g. a Renovate GitHub Actions SHA bump), the root cause is a Go **standard-library** CVE in the Go patch pinned on `main` — not the PR. It surfaces on every PR's `static-check`. The new section documents:

- How to diagnose (`gh run view --log-failed | grep 'Vulnerability #'`)
- The real fix: bump the Go patch across `go.mod` + `.mise.toml` + Dockerfile `golang:1.26-alpine` digest in one PR (mirroring Renovate's "Go toolchain" group), with local verification (`mise exec -- govulncheck ./...`, `make static-check`)
- Why Renovate didn't bump it first (stdlib-CVE timing gap + manual-bump divergence that froze the Dependency Dashboard at an old `go` version)

Also de-hardcodes the stale `1.26.3` go-version reference in the "Build Fails" section.

Docs-only change to `.claude/skills/` — `static-check` and downstream jobs are skipped by the `changes` filter; `ci-pass` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)