### PR TITLE
docs(agents): sync stale toolchain refs (gvm->mise, Go 1.26->1.26.4, Echo v5.1.1)

### DIFF
--- a/.claude/agents/builder.md
+++ b/.claude/agents/builder.md
@@ -6,8 +6,8 @@ You are the build engineer for the **flight-path** Go microservice. Your role is
 
 ## Project Context
 
-- **Language**: Go 1.26, managed via gvm
-- **Framework**: Echo v5 (v5.0.4)
+- **Language**: Go 1.26.4, managed via mise
+- **Framework**: Echo v5 (v5.1.1)
 - **Build flags**: `GOFLAGS=-mod=mod`, `CGO_ENABLED=0`
 - **Target**: `GOOS=linux GOARCH=amd64` (binary named `server`)
 - **Entry point**: `main.go`

--- a/.claude/agents/ci-validator.md
+++ b/.claude/agents/ci-validator.md
@@ -143,7 +143,7 @@ make static-check && make build && make test && make fuzz && make e2e
 | OWASP ZAP | `zaproxy/action-api-scan` action | Docker image or skip |
 | Node.js | `actions/setup-node` | nvm (installed by `make deps`) |
 | Newman | `npm install -g newman` | Installed by `make deps` |
-| Go version | From `go.mod` via `setup-go` | gvm or system Go |
+| Go version | From `go.mod` via mise (`jdx/mise-action`) | mise or system Go |
 | Server startup wait | `sleep 6s` (hardcoded) | Poll with curl (more reliable) |
 
 ## Failure Analysis

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -6,7 +6,7 @@ You are a senior Go code reviewer for the **flight-path** microservice. Your rol
 
 ## Project Context
 
-- **Language**: Go 1.26, Echo v5
+- **Language**: Go 1.26.4, Echo v5
 - **Style**: gofmt, 60+ linters via `.golangci.yml`, lines < 120 chars
 - **Pattern**: Handler struct methods, table-driven tests, immutable data
 - **Conventions**: `internal/handlers/` for handlers + business logic, `internal/routes/` for routing, `pkg/api/` for public types

--- a/.claude/agents/devils-advocate.md
+++ b/.claude/agents/devils-advocate.md
@@ -14,7 +14,7 @@ You are a senior adversarial reviewer for the **flight-path** Go microservice. Y
 
 ## Project Context
 
-- **Stack**: Go 1.26, Echo v5, Swagger/Swaggo
+- **Stack**: Go 1.26.4, Echo v5, Swagger/Swaggo
 - **Core**: `FindItinerary()` — O(n) two-pass map algorithm (`internal/handlers/api.go`)
 - **CI pipeline**: static-check → builds → tests → integration (Newman E2E) → DAST (OWASP ZAP) → image-scan (Trivy)
 - **Known issue**: Docker container crashes at runtime (`.env` not copied to runtime stage, `godotenv.Load()` calls `log.Fatalf`)

--- a/.claude/agents/security-scanner.md
+++ b/.claude/agents/security-scanner.md
@@ -6,7 +6,7 @@ You are the security specialist for the **flight-path** Go microservice. Your ro
 
 ## Project Context
 
-- **Stack**: Go 1.26, Echo v5, Alpine Docker image
+- **Stack**: Go 1.26.4, Echo v5, Alpine Docker image
 - **Security tools in CI**: gosec, govulncheck, gitleaks, Trivy (fs + image), OWASP ZAP (DAST)
 - **Security middleware**: CORS, Secure headers, error handler (hides internals), Recover
 - **Endpoint**: POST `/calculate` — accepts `[][]string`, returns `[]string`

--- a/.claude/agents/tech-architect.md
+++ b/.claude/agents/tech-architect.md
@@ -7,7 +7,7 @@ You are the technical architect for the **flight-path** Go microservice. Your ro
 ## Project Context
 
 - **Type**: Single-endpoint REST API microservice
-- **Stack**: Go 1.26, Echo v5, Swagger/Swaggo, Alpine Docker
+- **Stack**: Go 1.26.4, Echo v5, Swagger/Swaggo, Alpine Docker
 - **Architecture**: Layered — handlers (HTTP + business logic) → routes → public types
 - **Scale**: ~500 lines of application code, 1 endpoint + health check + Swagger
 


### PR DESCRIPTION
Completes the doc sweep for the Go 1.26.4 bump. Fixes `.claude/agents/*.md`: `builder.md` (gvm->mise, Echo v5.0.4->v5.1.1), `ci-validator.md` (gvm/setup-go->mise), and four agent stack lines (Go 1.26->1.26.4). The minor-only `Go 1.26` strings were missed by the earlier exact-`1.26.3` sweep. Docs-only (.claude/**) — `ci-pass` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)