### PR TITLE
feat(ci): check-docs-go-version drift gate + version-bump runbooks

### DIFF
--- a/.claude/skills/troubleshooting/SKILL.md
+++ b/.claude/skills/troubleshooting/SKILL.md
@@ -93,6 +93,19 @@ make static-check                # the full gate that was failing
 make check-go-alignment          # go.mod and .mise.toml must agree
 ```
 
+**The bump is not done at the pins — sweep the docs in the SAME PR.** Prose
+docs (`README.md`, `CLAUDE.md`, `specs/`, `docs/ARCHITECTURE.md`, the
+`.claude/agents/*.md` and `.claude/skills/*.md` files) are not touched by
+Renovate and go stale on merge. Do NOT grep one exact version string — grep the
+broad pattern across the whole tree and prove zero stale remain:
+```bash
+git ls-files | xargs grep -nE 'go ?1\.26|gvm' 2>/dev/null   # inspect every hit
+make check-docs-go-version                                   # the drift gate; must pass
+```
+`check-docs-go-version` runs inside `static-check` and reds CI if any live-state
+doc still shows an old Go patch — never declare the bump done until it is green.
+Full procedure: the "Bumping the Go version" checklist in the `workflows` skill.
+
 Then PR the fix to `main` (do NOT push onto the Renovate branch — it can
 auto-merge from under you). Renovate auto-rebases the in-flight PRs onto the
 fix and they go green.

--- a/.claude/skills/workflows/SKILL.md
+++ b/.claude/skills/workflows/SKILL.md
@@ -101,6 +101,42 @@ Pipeline in `.github/workflows/ci.yml`, runs on push and PRs (with `paths-ignore
 - **Automated**: Renovate auto-creates and auto-merges PRs (config: `renovate.json`)
 - **Manual**: `make update` (runs `go get -u && go mod tidy`)
 
+## Bumping the Go version
+
+A Go patch bump is **ONE PR** that updates the source-of-truth pins **and**
+every live-state doc — never split the doc sweep into a follow-up PR (doing so
+is how stale version strings ship).
+
+1. Get the target patch and the new base-image digest, and confirm it:
+   ```bash
+   docker buildx imagetools inspect golang:1.26-alpine --format '{{.Manifest.Digest}}'
+   docker run --rm golang:1.26-alpine@<digest> go version   # MUST show goX.Y.Z
+   ```
+2. Bump the three pins: `go.mod` (`go X.Y.Z`), `.mise.toml` (`go = "X.Y.Z"`),
+   `Dockerfile` (`golang:1.26-alpine@sha256:<digest>` — so the docker job's
+   Trivy scan doesn't ship a binary built against the old stdlib).
+3. `go mod tidy`; verify the bump cleared what prompted it:
+   ```bash
+   mise install go@X.Y.Z && mise exec -- govulncheck ./...   # "No vulnerabilities found"
+   ```
+4. **Sweep every live-state doc in the SAME commit.** Do NOT grep one exact
+   version string — grep the broad pattern across the whole tree and inspect
+   every hit, then prove zero stale remain:
+   ```bash
+   git ls-files | xargs grep -nE 'go ?1\.26|gvm' 2>/dev/null   # check each hit
+   ```
+   Update the patch number AND any version-implied staleness (toolchain manager
+   names like `gvm`→`mise`, framework versions). Leave dated history
+   (`docs/plan/`, `docs/research/`) unchanged — append, don't rewrite.
+5. Prove it before declaring done:
+   ```bash
+   make check-go-alignment && make check-docs-go-version && make static-check
+   ```
+
+`check-docs-go-version` is wired into `static-check`, so a forgotten doc sweep
+**reds CI and cannot merge** — it is the mechanical backstop for step 4. See the
+project `troubleshooting` skill for the govulncheck-fired-the-bump runbook.
+
 ## Quick Test Commands
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -231,8 +231,31 @@ check-go-alignment:
 		exit 1; \
 	fi
 
+#check-docs-go-version: @ Verify docs reference the same Go patch version as go.mod (drift guard)
+# Catches the recurring miss where a go.mod patch bump (e.g. 1.26.3 -> 1.26.4)
+# lands but prose docs keep advertising the old version. Scoped to the go.mod
+# minor series (e.g. 1.26.x) so it flags ONLY Go-version drift — never Echo,
+# Alpine, or tool versions — and ignores minor-only mentions like "Go 1.26".
+# Dated history under docs/plan and docs/research is excluded (append, don't
+# rewrite). Wired into static-check next to check-go-alignment so a forgotten
+# doc sweep fails CI in milliseconds instead of shipping stale.
+check-docs-go-version:
+	@want=$$(grep -oP '^go \K[0-9]+\.[0-9]+\.[0-9]+' go.mod); \
+	minor=$${want%.*}; \
+	minore=$$(printf '%s' "$$minor" | sed 's/\./\\./g'); \
+	bad=$$(git ls-files '*.md' ':(exclude)docs/plan/**' ':(exclude)docs/research/**' \
+	      | xargs grep -nE "$$minore\.[0-9]+" 2>/dev/null \
+	      | grep -vF "$$want" || true); \
+	if [ -n "$$bad" ]; then \
+		echo "ERROR: docs reference a Go $$minor.x version != go.mod ($$want):"; \
+		echo "$$bad"; \
+		echo "  Fix: update every live-state doc to $$want, then re-run."; \
+		echo "  See the 'Bumping the Go version' checklist in the workflows skill."; \
+		exit 1; \
+	fi
+
 #static-check: @ Run code static check
-static-check: check-go-alignment format-check lint-ci lint sec vulncheck secrets trivy-fs mermaid-lint release-check
+static-check: check-go-alignment check-docs-go-version format-check lint-ci lint sec vulncheck secrets trivy-fs mermaid-lint release-check
 	@echo "Static check passed."
 
 #build: @ Build REST API server's binary


### PR DESCRIPTION
Prevents the recurring class surfaced this session: a `go.mod` Go patch bump lands but prose docs keep advertising the old version (and the follow-up sweep gets scoped to one exact string, missing files that wrote the version differently).

### `make check-docs-go-version` (wired into `static-check`)
Derives the Go minor from `go.mod` and fails if any **live-state** `.md` references a different patch in that series. Scoped so it flags **only** Go-version drift — never Echo/Alpine/tool versions — ignores minor-only mentions (`Go 1.26`), and excludes dated history (`docs/plan/`, `docs/research/`). Negative-tested: GREEN on clean tree, **RED (rc=2, pinpoints the line)** on a staled doc, GREEN on restore.

A forgotten doc sweep now **reds CI and cannot merge** — the mechanical backstop.

### Skill runbooks
- **workflows**: new "Bumping the Go version" checklist — one PR bumps the three pins **and** sweeps every live-state doc; verify with the gate.
- **troubleshooting**: the govulncheck runbook's fix now ends with the doc sweep + **broad-grep-prove-zero** method (not a narrow exact-string sweep) + the gate.

Addresses the two process failures from this session: (1) doc sweep belongs in the bump PR, (2) prove completeness by grepping the broad pattern across the whole tree, not one string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)