### PR TITLE
docs: fix pre-existing staleness (godotenv→envfile, build-image→image-*, paths-ignore→changes, alpine 3.23.4)

### DIFF
--- a/.claude/agents/dependency-manager.md
+++ b/.claude/agents/dependency-manager.md
@@ -18,8 +18,9 @@ You are the dependency manager for the **flight-path** Go microservice. Your rol
 |---------|---------|
 | `github.com/labstack/echo/v5` | Web framework |
 | `github.com/swaggo/echo-swagger/v2` | Swagger UI middleware |
-| `github.com/swaggo/swag` | Swagger doc generator |
-| `github.com/joho/godotenv` | .env file loading |
+| `github.com/swaggo/swag/v2` | Swagger doc generator |
+
+`.env` parsing is handled in-house by `internal/envfile` (the `github.com/joho/godotenv` dependency was removed), so it is not a third-party dependency.
 
 ### Development Tools
 | Tool | Purpose | Install |
@@ -127,7 +128,7 @@ For each dependency, assess:
 ### Known Risks
 
 - **Echo v5**: Relatively new major version. Monitor for stability issues
-- **godotenv**: Simple library, low risk, but `log.Fatalf` on failure is a project-level risk
+- **.env parsing**: in-house `internal/envfile` (no external dependency since `godotenv` was removed) — a missing file is a no-op; only a malformed/unreadable file returns an error
 - **swag**: Build-time only, no runtime risk. Version pinning important for reproducible docs
 - **echo-swagger/v2**: Couples Swagger UI to Echo version. Update together
 

--- a/.claude/agents/devils-advocate.md
+++ b/.claude/agents/devils-advocate.md
@@ -16,8 +16,8 @@ You are a senior adversarial reviewer for the **flight-path** Go microservice. Y
 
 - **Stack**: Go 1.26.4, Echo v5, Swagger/Swaggo
 - **Core**: `FindItinerary()` — O(n) two-pass map algorithm (`internal/handlers/api.go`)
-- **CI pipeline**: static-check → builds → tests → integration (Newman E2E) → DAST (OWASP ZAP) → image-scan (Trivy)
-- **Known issue**: Docker container crashes at runtime (`.env` not copied to runtime stage, `godotenv.Load()` calls `log.Fatalf`)
+- **CI pipeline**: static-check → build → test → integration-test → e2e (Newman) → dast (OWASP ZAP) → docker (Trivy image scan); tag-gated goreleaser; all aggregated by `ci-pass`
+- **Config loading**: in-house `internal/envfile.Load` (replaced `godotenv`) — a missing `.env` is a no-op and the port defaults to 8080, so there is no runtime crash
 - **Linting**: 60+ linters enabled via golangci-lint v2
 - **Security tools**: gosec, govulncheck, gitleaks, Trivy (filesystem + image), OWASP ZAP
 
@@ -51,7 +51,7 @@ Evaluate the current architecture against these criteria:
 - **Algorithm placement**: Business logic lives in `internal/handlers/api.go` alongside HTTP handlers — is this the right home?
 - **Middleware stack**: CORS `*`, security headers, request logging, recover — all needed? Any missing?
 - **Error handling**: JSON error format consistency across all paths
-- **Configuration**: `.env` + `godotenv` + `flag` — three mechanisms for config. Too many?
+- **Configuration**: `.env` (in-house `envfile`) + `-env-file` flag + environment variables — three mechanisms for config. Too many?
 
 ### Phase 4: Alternative Research
 
@@ -115,7 +115,7 @@ Always probe these known areas:
 
 ### Dependencies
 - Echo v5 — is it stable enough for production? What's the migration path if deprecated?
-- `godotenv` + `log.Fatalf` pattern — should config loading be more resilient?
+- Config loading via in-house `envfile` — a missing `.env` is tolerated (no-op); is the remaining `log.Fatalf` on a malformed/unreadable file the right failure mode?
 - Swagger generation (`swag`) as a build dependency — adds CI time. Worth it?
 
 ### Testing Gaps

--- a/.claude/agents/docker-ops.md
+++ b/.claude/agents/docker-ops.md
@@ -7,10 +7,10 @@ You are the Docker and container operations specialist for the **flight-path** G
 ## Project Context
 
 - **Dockerfile**: Multi-stage build (build + runtime)
-- **Base images**: `golang:1.26-alpine` (build), `alpine:3.23` (runtime)
-- **Build script**: `scripts/build-image.sh`
-- **CI job**: `image-scan` in `.github/workflows/ci.yml`
-- **Known issue**: Container crashes — `.env` not copied to runtime stage, `godotenv.Load()` calls `log.Fatalf`
+- **Base images**: `golang:1.26-alpine` (build), `alpine:3.23.4` (runtime), both SHA256-pinned
+- **Build**: `make image-build` → `docker buildx build --load -t flight-path:local .` (there is no `build-image.sh`; `scripts/build.sh` is a cross-compile matrix, not an image build)
+- **CI job**: `docker` in `.github/workflows/ci.yml` (build + Trivy image scan + smoke/structure test; push + cosign sign on tags)
+- **Runtime config**: the `.env` file is optional — `internal/envfile.Load` no-ops on a missing file and `app.Port()` defaults to `8080`, so the container starts cleanly with no `.env`
 
 ## Current Dockerfile Analysis
 
@@ -19,19 +19,19 @@ You are the Docker and container operations specialist for the **flight-path** G
 # - Uses BuildKit cache mounts for GOMODCACHE and GOCACHE
 # - Requires --build-arg GOMODCACHE and GOCACHE
 
-# Runtime stage: alpine:3.23
-# - Non-root user (srvuser:1000)
-# - MISSING: .env file → causes runtime crash
-# - Has both CMD and ENTRYPOINT → potential conflict
-# - No HEALTHCHECK instruction
+# Runtime stage: alpine:3.23.4
+# - Non-root user (srvuser:srvgroup, uid/gid 1000)
+# - Binary copied to /main; single ENTRYPOINT ["/main"] (no CMD)
+# - No .env needed — envfile.Load no-ops on a missing file, port defaults to 8080
+# - HEALTHCHECK present (wget against the configured host/port)
 ```
 
 ## Build Commands
 
-### Standard Build (cross-platform)
+### Standard Build (single platform, loaded into the local daemon)
 
 ```bash
-make build-image
+make image-build
 ```
 
 Or manually:
@@ -66,11 +66,14 @@ docker buildx build --load \
 ### Run Container
 
 ```bash
-# With .env mounted (workaround for known issue)
-docker run --rm -p 8080:8080 -v "$(pwd)/.env:/app/.env:ro" flight-path:local
+# No .env needed — defaults to port 8080
+docker run --rm -p 8080:8080 flight-path:local
 
-# Or pass env vars directly
-docker run --rm -p 8080:8080 -e SERVER_PORT=8080 flight-path:local
+# Override the port if desired
+docker run --rm -p 9090:9090 -e SERVER_PORT=9090 flight-path:local
+
+# Or use the Make target (binds a free host port, --env-file .env.example)
+make image-run
 ```
 
 ### Health Check
@@ -82,7 +85,7 @@ curl -sf http://localhost:8080/ && echo "OK" || echo "FAIL"
 ### Smoke Test
 
 ```bash
-docker run -d --name fp-test -p 8080:8080 -v "$(pwd)/.env:/.env:ro" flight-path:local
+docker run -d --name fp-test -p 8080:8080 flight-path:local
 sleep 3
 
 # Health check
@@ -120,45 +123,19 @@ docker history flight-path:local
 docker inspect flight-path:local --format '{{json .Config}}' | python3 -m json.tool
 ```
 
-## Known Issues and Fixes
+## Previously-Known Issues (all resolved — kept for context)
 
-### Issue 1: Container Crash (`.env` not in runtime stage)
+These were real in earlier revisions and have since been fixed in the
+Dockerfile/source. If older notes still describe them as open, they don't apply:
 
-**Root cause**: `godotenv.Load()` in `main.go` calls `log.Fatalf` when `.env` is missing.
-
-**Workarounds**:
-1. Mount `.env` at runtime: `-v "$(pwd)/.env:/.env:ro"`
-2. Pass env vars directly: `-e SERVER_PORT=8080`
-
-**Proper fix** (requires code change):
-- Copy `.env` to runtime stage: `COPY --from=build /app/.env /`
-- Or make `godotenv.Load()` non-fatal when env vars are already set
-- Or use `-env-file` flag with a default fallback
-
-### Issue 2: CMD + ENTRYPOINT Conflict
-
-Current:
-```dockerfile
-CMD ["/bin/sh", "-c", "./main"]
-ENTRYPOINT [ "./main" ]
-```
-
-When both are set, CMD becomes arguments to ENTRYPOINT. This runs: `./main /bin/sh -c ./main` — likely causes unexpected behavior.
-
-**Fix**: Use one or the other:
-```dockerfile
-ENTRYPOINT ["./main"]
-# OR
-CMD ["./main"]
-```
-
-### Issue 3: No HEALTHCHECK
-
-Add to Dockerfile:
-```dockerfile
-HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:8080/ || exit 1
-```
+- **Container crash on missing `.env`** — RESOLVED. `internal/envfile.Load`
+  treats a missing file as a no-op (the in-house package replaced
+  `github.com/joho/godotenv`, which used to `log.Fatal`); `app.Port()` defaults
+  to `8080`. No `.env` mount or `-e SERVER_PORT` is required to start.
+- **CMD + ENTRYPOINT conflict** — RESOLVED. The runtime stage now has a single
+  `ENTRYPOINT ["/main"]` and no `CMD`.
+- **No HEALTHCHECK** — RESOLVED. The Dockerfile defines a `HEALTHCHECK` that
+  `wget`s the configured host/port.
 
 ## Security Checklist
 

--- a/.claude/agents/tech-architect.md
+++ b/.claude/agents/tech-architect.md
@@ -59,8 +59,8 @@ For each layer, evaluate:
 - Trade-off: Separate package for one type vs. putting it in handlers
 
 **Configuration**:
-- Three mechanisms: `.env` file (godotenv), flags (`-env-file`), environment variables
-- `log.Fatalf` on missing `.env` — inflexible for containerized deployment
+- Three mechanisms: `.env` file (in-house `envfile`), flags (`-env-file`), environment variables
+- Missing `.env` is tolerated (`envfile.Load` no-ops) and the port defaults to 8080 — container-friendly; `log.Fatalf` only fires on a malformed/unreadable file
 
 ### Design Patterns in Use
 

--- a/.claude/commands/docker.md
+++ b/.claude/commands/docker.md
@@ -1,11 +1,9 @@
 Build and test the Docker image locally:
 
 1. Run pre-build checks: `make lint` and `make test`
-2. Build the Docker image: `make build-image`
-3. If the build succeeds, run the container: `docker run -d -p 8080:8080 --name flight-path-test flight-path:latest`
-4. Wait for the container to be ready (poll `http://localhost:8080/`)
-5. Run a quick smoke test using curl against the `/calculate` endpoint with test data: `[["SFO","ATL"],["ATL","EWR"]]`
-6. Report the health check and smoke test results
-7. Stop and remove the test container: `docker stop flight-path-test && docker rm flight-path-test`
+2. Build the Docker image locally: `make image-build` (produces `flight-path:local`)
+3. Simplest path: `make image-test` — builds, runs the container on a free host port, and runs the smoke + structure tests. To do it by hand instead: `make image-run` (binds an ephemeral host port, `--env-file .env.example`), then `make image-smoke-test`
+4. Report the health check and smoke test results
+5. Tear down: `make image-stop`
 
-If port 8080 is already in use, report the conflict and suggest a fix before proceeding.
+The image runs fine without a `.env` (the port defaults to 8080; override with `SERVER_PORT`). `make image-run` picks a free host port automatically, so port-8080 conflicts don't arise; if you run a manual `docker run -p 8080:8080`, report any conflict first.

--- a/.claude/skills/environment/SKILL.md
+++ b/.claude/skills/environment/SKILL.md
@@ -10,7 +10,7 @@ description: >
 
 ## Go (via mise)
 
-Pinned in `.mise.toml` at repo root: `go = "1.26.4"`. Activated automatically via shell hook (`eval "$(mise activate bash)"` or zsh/fish equivalent in `~/.zshrc`). `make deps` installs the pinned Go through mise; CI uses `actions/setup-go` with `go-version-file: 'go.mod'`.
+Pinned in `.mise.toml` at repo root: `go = "1.26.4"`. Activated automatically via shell hook (`eval "$(mise activate bash)"` or zsh/fish equivalent in `~/.zshrc`). `make deps` installs the pinned Go through mise; CI installs it the same way via `jdx/mise-action` (which reads `.mise.toml`, mirrored from `go.mod`) — not `actions/setup-go`.
 
 ## Node.js (via nvm)
 
@@ -53,21 +53,21 @@ Most build targets depend on `deps` and auto-install missing tools.
 | `bench-compare` | deps | Compare latest two benchmarks |
 | `build` | api-docs | Compile binary |
 | `run` | build | Build and start server |
-| `check` | lint, sec, vulncheck, secrets, test, api-docs, build | Pre-commit checklist |
-| `ci` | static-check, build, test, fuzz | Local CI pipeline |
-| `ci-full` | ci, coverage-check | CI + coverage threshold |
+| `check` | ci | Alias for `make ci` (full local pipeline) |
+| `ci` | deps, static-check, test, integration-test, coverage, coverage-check, build, fuzz, deps-prune-check | Local CI pipeline |
+| `ci-run` | deps | Run the GitHub Actions workflow locally via act |
 | `coverage` | — | Test coverage report |
 | `coverage-check` | coverage | Verify 80% threshold |
 | `clean` | — | Remove build artifacts and test cache |
-| `image-build` | build | Build Docker image locally |
+| `image-build` | build | Build Docker image locally (`flight-path:local`) |
 | `image-run` | image-stop, image-build | Run container locally (detached) |
 | `image-stop` | — | Stop the locally running container |
 | `image-push` | image-build | Push Docker image to GHCR |
 | `image-smoke-test` | — | Smoke-test a pre-built container |
-| `image-test` | image-build, image-smoke-test | Build + smoke test container |
+| `image-structure-test` | — | Validate image metadata + binary (container-structure-test) |
+| `image-test` | image-build, image-smoke-test, image-structure-test | Build + smoke-test + structure-test |
 | `image-scan` | deps, build | Build image + Trivy scan (trivy installed via mise) |
-| `build-image` | deps, api-docs, lint, sec, vulncheck, secrets | Multi-platform build + push |
-| `release` | lint, sec, vulncheck, test, api-docs, build | Tag and push release |
+| `release` | ci | Tag and push release (runs full `ci` first) |
 | `e2e` | deps | Newman E2E tests |
 | `update` | — | Update Go dependencies |
 

--- a/.claude/skills/troubleshooting/SKILL.md
+++ b/.claude/skills/troubleshooting/SKILL.md
@@ -49,7 +49,7 @@ go clean -cache           # Nuclear option
 
 - `make build` depends on `api-docs` (which depends on `deps`), then compiles
 - Ensure `GOFLAGS=-mod=mod` is set (Makefile sets this automatically)
-- Use `make check` for the full pre-commit chain: `lint sec vulncheck secrets test api-docs build`
+- Use `make check` (alias for `make ci`) for the full local pipeline: static-check + test + integration-test + coverage + coverage-check + build + fuzz + deps-prune-check
 
 ## `static-check` / `govulncheck` Fails on an Unrelated PR (Go stdlib CVE)
 
@@ -154,21 +154,26 @@ make image-build                    # Build locally (single platform, uses build
 docker build --no-cache -t flight-path:debug .  # Build without cache
 ```
 
-- Image: multi-stage Alpine build (`golang:1.26-alpine` -> `alpine:3.23.3`)
-- Non-root user: `srvuser:1000`
+- Image: multi-stage Alpine build (`golang:1.26-alpine` -> `alpine:3.23.4`)
+- Non-root user: `srvuser:srvgroup` (uid/gid 1000)
 - `CGO_ENABLED=0`, platforms: `linux/amd64`, `linux/arm64`, `linux/arm/v7`
-- `make build-image` runs checks first (`deps api-docs lint sec vulncheck secrets`) then pushes to Docker Hub
+- `make image-push` builds then pushes to GHCR (`ghcr.io/<user>/flight-path:<tag>`); requires `GH_ACCESS_TOKEN`. Multi-arch build + cosign signing happen in the `docker` CI job on tag pushes
 
-## Docker Container Crashes at Runtime
+## Docker Container: Port Configuration
 
-Known issue: `.env` file is not copied into the Docker runtime stage, and `godotenv.Load()` calls `log.Fatalf` on error.
+The container runs fine **without** a `.env` file. `internal/envfile.Load`
+treats a missing file as a no-op (returns nil), and `app.Port()` defaults to
+`8080` when `SERVER_PORT` is unset — so there is no "crashes without .env"
+issue (the in-house `envfile` package replaced `github.com/joho/godotenv`,
+which used to `log.Fatal` on a missing file).
 
-Workaround: pass `SERVER_PORT` as environment variable:
+To run on a non-default port, set `SERVER_PORT` via `-e` (or an env-file):
 ```bash
-docker run -d -p 8080:8080 -e SERVER_PORT=8080 flight-path:local
+docker run -d -p 9090:9090 -e SERVER_PORT=9090 flight-path:local
 ```
 
-Or use `make image-run` / `make image-test` which handle this automatically.
+`make image-run` / `make image-test` handle this automatically — they bind a
+free host port and pass `--env-file .env.example`.
 
 ## Tool Not Found
 
@@ -177,7 +182,7 @@ make deps                           # Install all tools
 export PATH=$PATH:$(go env GOPATH)/bin  # Ensure tools are on PATH
 ```
 
-- `newman` requires Node.js — `make deps` installs both via nvm/npm
+- `newman` requires Node.js — `make deps` provisions Node via mise and installs newman via pnpm (corepack)
 
 ## Diagnostic Commands
 

--- a/.claude/skills/workflows/SKILL.md
+++ b/.claude/skills/workflows/SKILL.md
@@ -32,7 +32,7 @@ Benchmarks run: `go test ./internal/handlers/ -bench=. -benchmem -benchtime=3s`
 
 Quick way:
 ```bash
-make check    # Runs: lint sec vulncheck secrets test api-docs build
+make check    # Alias for `make ci` — runs the full local pipeline (see "Local CI" below)
 ```
 
 Or individual steps:
@@ -49,52 +49,54 @@ make build          # Compile binary (depends on api-docs)
 ## Local CI
 
 ```bash
-make ci             # static-check + build + test + fuzz
-make ci-full        # ci + coverage-check (80% threshold)
+make ci       # full pipeline: deps + static-check + test + integration-test + coverage + coverage-check + build + fuzz + deps-prune-check
+make ci-run   # run the GitHub Actions workflow locally via act
 ```
+
+`make check` is an alias for `make ci`.
 
 ## Release
 
-1. Ensure clean main branch, all checks pass
-2. Run full checks: `make check`
-3. `make release` — validates semver tag (`vN.N.N`), updates `pkg/api/version.txt`, commits, tags, pushes
-4. GitHub Actions release workflow triggers on tag push (uses GoReleaser)
+1. Ensure a clean `main` branch with an upstream set
+2. `make release` — runs the full `ci` pipeline first, then validates the semver tag (`vN.N.N`), updates `pkg/api/version.txt`, commits, tags, and pushes
+3. On the tag push, the tag-gated `goreleaser` and `docker` jobs in `.github/workflows/ci.yml` run (there is **no** separate `release.yml`): GoReleaser builds binaries/archives/checksums + the GitHub Release, and `docker` pushes the cosign-signed multi-arch image to GHCR. They are serialized via `needs:` so a tag produces both artifacts or neither.
 
-`make release` depends on: `lint sec vulncheck test api-docs build`
+`make release` depends on `ci` (the full local pipeline).
 
 ## Docker
 
 ```bash
-make image-build                         # Build locally (single platform, buildx)
-make image-run                           # Build + run container (-e SERVER_PORT=8080)
-make image-test                          # Build + smoke test (health + API check)
-make build-image                         # Multi-platform build + push to Docker Hub
+make image-build    # Build image locally (single platform, buildx)
+make image-run      # Build + run container (binds a free host port, --env-file .env.example)
+make image-test     # Build + smoke-test + structure-test
+make image-push     # Build + push to GHCR (requires GH_ACCESS_TOKEN)
 ```
 
-- Image: multi-stage Alpine build (`golang:1.26-alpine` -> `alpine:3.23.3`)
-- Non-root user: `srvuser:1000`, `CGO_ENABLED=0`
+- Image: multi-stage build (`golang:1.26-alpine` -> `alpine:3.23.4`)
+- Non-root user: `srvuser:srvgroup` (uid/gid 1000), `CGO_ENABLED=0`
 - Platforms: `linux/amd64`, `linux/arm64`, `linux/arm/v7`
-- Registry: `andriykalashnykov/flight-path:latest` on Docker Hub
-- `make build-image` runs checks first (`deps api-docs lint sec vulncheck secrets`) then calls `scripts/build-image.sh`
+- Registry: GHCR — `make image-push` tags `ghcr.io/<user>/flight-path:<git-tag>`. The release-grade multi-arch build + cosign signing is done by the `docker` job in ci.yml on tag pushes, not by the local target.
 
 ## CI Pipeline (GitHub Actions)
 
-Pipeline in `.github/workflows/ci.yml`, runs on push and PRs (with `paths-ignore` for non-critical files like docs, images, benchmarks, and metadata — `CLAUDE.md` is excluded from ignore via `!CLAUDE.md` negation):
+Pipeline in `.github/workflows/ci.yml`, runs on push to `main`, tags `v*`, and PRs. A `changes` job (`dorny/paths-filter`) emits a `code` output; heavy jobs gate on `needs.changes.outputs.code == 'true'`, so doc-only changes run only `changes` + `ci-pass`. (Uses a `changes` filter, NOT trigger-level `paths-ignore` — this avoids the Repository-Ruleset deadlock where a skipped workflow never reports the required `ci-pass` check.)
 
-| Job | Depends on | What it runs |
+| Job | Needs | What it runs |
 |---|---|---|
-| `static-check` | — | `make static-check` (lint, sec, vulncheck, secrets, lint-ci) + Trivy FS scan |
-| `builds` | static-check | `make build` + upload binary artifact |
-| `tests` | static-check | `make test` + `make fuzz` |
-| `integration` | builds, tests | Download artifact, start server, install Newman, `make e2e` |
-| `dast` | integration | Start server, OWASP ZAP API scan against Swagger spec |
-| `image-scan` | builds | Build Docker image, Trivy image scan |
-| `container-test` | image-scan | Build image, run container, health + API smoke test |
+| `changes` | — | `dorny/paths-filter` — emits the `code` gate output |
+| `static-check` | changes | `make static-check` (incl. check-go-alignment, check-docs-go-version, lint, sec, vulncheck, secrets, trivy-fs, mermaid-lint, release-check) |
+| `build` | changes, static-check | `make build` + upload binary artifact |
+| `test` | changes, static-check | `make coverage` + `make coverage-check` (80%) + `make fuzz` |
+| `integration-test` | changes, static-check | `make integration-test` (full HTTP stack via httptest) |
+| `e2e` | changes, build, test | Download binary (fallback rebuild), start server, `make e2e-quick` (Newman) |
+| `dast` | changes, static-check, test | OWASP ZAP API scan (skipped under `act`) |
+| `goreleaser` | changes, static-check, build, test, integration-test, e2e, dast | **tag-only** — GoReleaser binaries/archives/checksums + GitHub Release |
+| `docker` | changes, static-check, build, test, integration-test, goreleaser | Build + Trivy image scan + smoke/structure test every push; on tags also push + cosign-sign multi-arch to GHCR |
+| `ci-pass` | all of the above | Aggregator (`if: always()`); single required check for branch protection (skipped jobs count as success) |
 
-- Go version read from `go.mod` via `actions/setup-go`
-- Integration job sets up Node.js for Newman
-- Server readiness: polls with curl for up to 30 seconds
-- Release workflow (`.github/workflows/release.yml`) triggers on git tags via GoReleaser
+- Go + Node + the whole quality toolchain are installed by `jdx/mise-action` reading `.mise.toml` (which mirrors `go.mod` and `.nvmrc`) — not `actions/setup-go`/`setup-node`.
+- There is **no** `release.yml`; the release phase lives in `ci.yml` as the tag-gated `goreleaser` + `docker` jobs, so `ci-pass` aggregates CI and release into one green check.
+- Run the whole workflow locally with `make ci-run` (uses `act`).
 
 ## Dependency Updates
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ flight-path/
 │   └── .npmrc                           # pnpm configuration
 ├── img/                                 # README screenshots (Swagger UI, Newman output)
 ├── benchmarks/                          # Saved benchmark results (bench_YYYYMMDD_HHMMSS.txt)
-├── scripts/                             # build.sh, build-image.sh, wait-for-server.sh
+├── scripts/                             # build.sh (cross-compile matrix), pick-port.sh, wait-for-server.sh
 ├── .zap/rules.tsv                       # OWASP ZAP scan rules for DAST job
 ├── .golangci.yml                        # golangci-lint configuration (default: all)
 ├── Dockerfile                           # Multi-stage, multi-platform Docker build (Alpine)

--- a/specs/CI-CD.md
+++ b/specs/CI-CD.md
@@ -1,6 +1,6 @@
 # CI/CD Specification
 
-Every CI job and the full release pipeline live in a single workflow file (`.github/workflows/ci.yml`), with tag-gated sibling jobs for the release phase. Supporting workflows (`claude.yml`, `claude-ci-fix.yml`, `cleanup-runs.yml`) are separate.
+Every CI job and the full release pipeline live in a single workflow file (`.github/workflows/ci.yml`), with tag-gated sibling jobs for the release phase. Supporting workflows (`claude.yml`, `claude-ci-fix.yml`, `auto-merge.yml`, `cleanup-runs.yml`, `nightly-fuzz.yml`) are separate.
 
 ## `ci.yml`
 
@@ -10,7 +10,7 @@ Every CI job and the full release pipeline live in a single workflow file (`.git
 - Push of tags matching `v*`
 - Pull requests targeting `main`
 
-`paths-ignore` excludes documentation, images, benchmarks, `.claude/**`, and other non-critical files; `CLAUDE.md` is re-included via `!CLAUDE.md`. Tags are unaffected by `paths-ignore`.
+The workflow always triggers; a `changes` job (`dorny/paths-filter`) then gates every heavy job on whether the push touches code — a negated glob over `**.md`, `docs/**`, `specs/**`, `.claude/**`, `benchmarks/**`, image assets, and other non-critical paths, with `CLAUDE.md` re-included as project config. Doc-only changes run only `changes` + `ci-pass`. This deliberately avoids trigger-level `paths-ignore`, which would deadlock with the Repository Ruleset (a skipped workflow never reports the required `ci-pass` check). Tags always run the full pipeline.
 
 ### Permissions
 

--- a/specs/DOCKER.md
+++ b/specs/DOCKER.md
@@ -9,9 +9,9 @@
 - Cross-compile: `CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH`
 - Output: `/app/main`
 
-### Stage 2: Runtime (`alpine:3.23.3`)
+### Stage 2: Runtime (`alpine:3.23.4`)
 
-- Base: `alpine:3.23.3` (SHA256-pinned, Renovate-tracked)
+- Base: `alpine:3.23.4` (SHA256-pinned, Renovate-tracked)
 - Non-root user: `srvuser:srvgroup` (UID/GID 1000)
 - `HEALTHCHECK` hits `localhost:${SERVER_PORT:-8080}` (no `EXPOSE` directive — port is honored only at runtime via env)
 - Binary copied from build stage


### PR DESCRIPTION
Fixes the pre-existing staleness flagged after the Go-bump session. **Every claim verified against current source** before editing.

### What was wrong (and is now correct)
- **godotenv → envfile**: the "container crashes without `.env`" issue is **fixed**, not present — `internal/envfile.Load` no-ops on a missing file and `app.Port()` defaults to `8080` (godotenv was removed). Corrected across `docker-ops`, `devils-advocate`, `dependency-manager`, `tech-architect` agents and the `troubleshooting` skill, including the now-false CMD+ENTRYPOINT and no-HEALTHCHECK claims (the Dockerfile has a single `ENTRYPOINT ["/main"]` + a `HEALTHCHECK`).
- **Nonexistent `make build-image` / `scripts/build-image.sh`** → real targets `image-build`/`image-run`/`image-test`/`image-push` (GHCR, not Docker Hub; local tag `flight-path:local`). Fixed in `docker-ops`, `/docker` command, `environment` + `workflows` skills.
- **`make check`/`ci`/`release`** all run the full `ci` pipeline; **`make ci-full` doesn't exist** (it's `ci-run`). Fixed `environment` + `workflows` skills.
- **CI**: a `changes`/`dorny/paths-filter` gate (NOT trigger-level `paths-ignore`); toolchain via `jdx/mise-action` (NOT `actions/setup-go`); no separate `release.yml`. Fixed `workflows` skill CI table, `environment` skill, `specs/CI-CD.md`.
- **`alpine:3.23.3` → `alpine:3.23.4`** (`specs/DOCKER.md`); `CLAUDE.md` `scripts/` listing corrected.

### Deliberately left unchanged
`docs/IMPLEMENTATION-PLAN.md` and `docs/SECURITY-TOOLS-ANALYSIS.md` — dated analysis/plan records (append, don't rewrite history).

Touches `CLAUDE.md` so full CI runs (incl. the new `check-docs-go-version` gate, which stays green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)