### PR TITLE
chore: project-review hardening + echo v5.2.0 security bump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,8 +304,8 @@ jobs:
       # Weekly cache-bust for the apk upgrade layer keeps DAST honest about
       # base-image security drift even when the Dockerfile is unchanged.
       - name: Compute APK cache-bust week
-        id: apk-week
-        run: echo "week=$(date -u +%Y-W%V)" >> "$GITHUB_OUTPUT"
+        id: apk-date
+        run: echo "date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
 
       - name: Build image for DAST
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
@@ -318,7 +318,7 @@ jobs:
           build-args: |
             GOMODCACHE=/go/pkg/mod
             GOCACHE=/root/.cache/go-build
-            APK_UPGRADE_WEEK=${{ steps.apk-week.outputs.week }}
+            APK_UPGRADE_DATE=${{ steps.apk-date.outputs.date }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -457,8 +457,8 @@ jobs:
       # Weekly cache-bust for the apk upgrade layer so the image picks up new
       # Alpine security patches even when the Dockerfile is unchanged.
       - name: Compute APK cache-bust week
-        id: apk-week
-        run: echo "week=$(date -u +%Y-W%V)" >> "$GITHUB_OUTPUT"
+        id: apk-date
+        run: echo "date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
 
       - name: Docker metadata
         id: meta
@@ -495,7 +495,7 @@ jobs:
           build-args: |
             GOMODCACHE=/go/pkg/mod
             GOCACHE=/root/.cache/go-build
-            APK_UPGRADE_WEEK=${{ steps.apk-week.outputs.week }}
+            APK_UPGRADE_DATE=${{ steps.apk-date.outputs.date }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -558,7 +558,7 @@ jobs:
           build-args: |
             GOMODCACHE=/go/pkg/mod
             GOCACHE=/root/.cache/go-build
-            APK_UPGRADE_WEEK=${{ steps.apk-week.outputs.week }}
+            APK_UPGRADE_DATE=${{ steps.apk-date.outputs.date }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,8 @@ make bench          # Run benchmarks
 make bench-save     # Save benchmark results with timestamp
 make bench-compare  # Compare two benchmark runs (auto-discovers latest two, or pass OLD=/NEW=)
 make check-go-alignment # Verify Go version matches across go.mod and .mise.toml
-make static-check   # All static analysis (check-go-alignment + format-check + lint-ci + lint + sec + vulncheck + secrets + trivy-fs + mermaid-lint + release-check)
+make check-docs-go-version # Verify the Go version referenced in docs matches go.mod
+make static-check   # All static analysis (check-go-alignment + check-docs-go-version + format-check + lint-ci + lint + sec + vulncheck + secrets + trivy-fs + mermaid-lint + release-check)
 make build          # Generate Swagger docs + compile binary
 make run            # Build and run server locally
 make e2e            # Self-contained: build + start server + run Newman + stop server
@@ -163,6 +164,7 @@ make deps-prune-check # Verify no prunable dependencies (CI gate)
 |----------|---------|---------|
 | `APP_NAME` | flight-path | Application name (used in Docker tags) |
 | `GO_VERSION` | (auto-extracted from go.mod) | Go version auto-parsed from `go.mod` via regex (mise also reads `go.mod` natively) |
+| `ACT_UBUNTU_VERSION` | act-latest-20260601 | Dated `catthehacker/ubuntu` runner image `make ci-run` maps to `ubuntu-latest` (Renovate-tracked Docker tag) |
 | `MERMAID_CLI_VERSION` | 11.15.0 | Mermaid diagram validator (Docker image — only ecosystem mise can't manage) |
 | `MISE_VERSION` | 2026.5.13 | mise bootstrap version (used by `make deps` if mise isn't already installed) |
 | `NODE_VERSION` | 24 | Node.js major version (source of truth: `.nvmrc` / `.mise.toml`; installed via mise) |
@@ -272,7 +274,7 @@ All quality/security tools below are installed in one pass by
 
 GitHub Actions CI workflow runs on push to `main`, tags `v*`, and pull requests. The workflow always triggers; a `changes` detector job (`dorny/paths-filter`) gates every heavy job on whether the push touches code (negated glob over `**.md`, `docs/**`, `specs/**`, `LICENSE`, `.gitignore`, `.claudeignore`, `.claude/**`, `benchmarks/**`, image assets — with `CLAUDE.md` re-included as project config). Doc-only PRs only run `changes` (~10s) and `ci-pass` (which treats skipped jobs as success). Avoids the trigger-level `paths-ignore` deadlock with Repository Rulesets — the workflow always reports `ci-pass`, satisfying required-check gates.
 
-Claude Code workflow (`claude.yml`) provides interactive mode (responds to `@claude` mentions, restricted to `OWNER`/`MEMBER`/`COLLABORATOR` author associations) and automated PR review on every non-draft PR. Claude CI Fix workflow (`claude-ci-fix.yml`) auto-triggers on CI failures via `workflow_run` (same-repo branches only) and uses a dual anti-recursion guard (bot-author check + `claude-fix-attempted` label) plus a 12K total input cap on CI logs to prevent prompt-injection context stuffing.
+Claude Code workflow (`claude.yml`) provides interactive mode only (responds to `@claude` mentions on issues, PR comments, and PR reviews, restricted to `OWNER`/`MEMBER`/`COLLABORATOR` author associations); it has no `pull_request` trigger and does not auto-review PRs. Claude CI Fix workflow (`claude-ci-fix.yml`) auto-triggers on CI failures via `workflow_run` (same-repo branches only) and uses a dual anti-recursion guard (bot-author check + `claude-fix-attempted` label) plus a 12K total input cap on CI logs to prevent prompt-injection context stuffing.
 
 All jobs live in `.github/workflows/ci.yml` (single-file layout matching the `/ci-workflow` skill template). The release-side `goreleaser` (tag-only) and `docker` (every push, push/sign tag-gated) are serialized via `needs:` so a tag either produces both the GitHub Release object AND the GHCR image, or neither — no half-released tags.
 
@@ -330,7 +332,7 @@ Items identified by upgrade analysis. Review periodically, act when conditions c
 - [ ] **govulncheck Renovate "abandoned" false positive**: `golang.org/x/vuln/cmd/govulncheck` last release (v1.1.4) is ~15 months old, which trips Renovate's release-age abandonment heuristic. The repo is actively maintained (main-branch pushes within days, 0 open issues, official Go sub-repo under `golang/`), and the CVE database the tool consults at `vuln.go.dev` updates server-side independently of the CLI's release cadence. Locally suppressed in `renovate.json` via `abandonmentThreshold: "5 years"` for this depName. Upstream tracked in [renovatebot/renovate discussions#42727](https://github.com/renovatebot/renovate/discussions/42727) under *Suggest an Idea* (proposal: fold commit activity + `archived` flag into the abandonment heuristic, not just release age) — when that lands, consider removing the local override. Originally filed as issue [#42725](https://github.com/renovatebot/renovate/issues/42725), auto-closed by the Renovate bot per its Issues-are-for-maintainers policy and re-filed as the Discussion above.
 - [ ] **Newman version lag**: Newman 6.2.2 is the latest release but ships stale internals — it emits `[DEP0176] DeprecationWarning: fs.F_OK is deprecated` (from `newman/lib/run/secure-fs.js:146`), bundles postman-sandbox 4.7.1 (upstream 6.6.1) + postman-runtime 7.39.1 (upstream 7.53.0), and carries an open moderate `pnpm audit` finding GHSA-w5hq-g745-h8pq (`uuid` <11.1.1, transitive via `postman-collection` — resolves to 3.4.0 / 8.3.2). The `uuid` advisory canNOT be safely fixed with a `pnpm-workspace.yaml` override: patched `uuid` is ≥11.1.1, a breaking API major over the v3/v8 the tree uses. All three resolve only with a newer Newman — check `pnpm view newman version` for Newman 7.x or a new 6.x release
 - [ ] **Postman Collection Format v3**: YAML-based format announced Mar 2026. Newman doesn't support it yet. Track Newman releases for v3 support
-- [ ] **swaggo/swag v1 indirect dep**: `echo-swagger/v2` pulls in `swag v1` transitively. Fix submitted upstream as [swaggo/echo-swagger#146](https://github.com/swaggo/echo-swagger/pull/146) (issue [#147](https://github.com/swaggo/echo-swagger/issues/147)). Check `gh pr view 146 --repo swaggo/echo-swagger --json state --jq '.state'`; when merged, run `go get github.com/swaggo/echo-swagger/v2@latest && go mod tidy` to drop swag v1 from `go.mod`
+- [ ] **swaggo/swag v1 indirect dep**: `echo-swagger/v2` (latest `v2.0.1`) still pulls in `swag v1` (`v1.16.6`) transitively. The original upstream fix [swaggo/echo-swagger#146](https://github.com/swaggo/echo-swagger/pull/146) was **closed unmerged on 2026-05-31**; tracking issue [#147](https://github.com/swaggo/echo-swagger/issues/147) remains **open**. No echo-swagger release drops swag v1 yet. Re-check periodically: `gh issue view 147 --repo swaggo/echo-swagger --json state --jq '.state'` and `gh api repos/swaggo/echo-swagger/releases --jq '[.[]|select(.tag_name|startswith("v2"))][0].tag_name'`; when a release lands that removes the swag v1 edge, run `go get github.com/swaggo/echo-swagger/v2@latest && go mod tidy` to drop it from `go.mod`
 
 ## Environment
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 **flight-path** is a Go REST API microservice that calculates flight paths from unordered flight segments. Given a list of [source, destination] pairs, it determines the complete path (starting airport to ending airport).
 
 - **Language**: Go 1.26.4 (via mise, optional — system Go works too)
-- **Framework**: Echo v5 (v5.1.1)
+- **Framework**: Echo v5 (v5.2.0)
 - **Docs**: Swagger/Swaggo (auto-generated)
 - **Version**: See `pkg/api/version.txt`
 - **Repo**: https://github.com/AndriyKalashnykov/flight-path
@@ -240,7 +240,7 @@ Update specs when changing architecture, API, or testing strategy.
 
 | Package | Version | Purpose |
 |---|---|---|
-| `github.com/labstack/echo/v5` | v5.1.1 | Web framework |
+| `github.com/labstack/echo/v5` | v5.2.0 | Web framework |
 | `github.com/swaggo/echo-swagger/v2` | v2.0.1 | Swagger UI |
 | `github.com/swaggo/swag/v2` | v2.0.0-rc5 | Swagger generator |
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,13 +16,13 @@ RUN --mount=type=cache,target="$GOMODCACHE" \
 # runtime image
 FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 AS runtime
 WORKDIR /
-# Weekly cache-bust for security updates. CI passes APK_UPGRADE_WEEK=$(date -u +%Y-W%V)
-# as a build-arg so the `apk upgrade` layer re-runs at least once per week, picking
+# Daily cache-bust for security updates. CI passes APK_UPGRADE_DATE=$(date -u +%Y-%m-%d)
+# as a build-arg so the `apk upgrade` layer re-runs at least once per day, picking
 # up new CVE fixes from the Alpine package repo even when the Dockerfile is unchanged.
-# Without this, the cached layer can serve stale package versions for weeks after a
-# CVE is fixed upstream (e.g., CVE-2026-28390 openssl: apk repo has 3.5.6-r0 but the
-# cached layer still ships 3.5.5-r0).
-ARG APK_UPGRADE_WEEK=manual
+# Without this, the cached layer can serve stale package versions after a CVE is fixed
+# upstream (e.g., CVE-2026-45447 openssl: apk repo has 3.5.7-r0 but a stale weekly-keyed
+# cache layer still shipped 3.5.6-r0 — daily granularity bounds that staleness to <24h).
+ARG APK_UPGRADE_DATE=manual
 RUN apk upgrade --no-cache
 # Non-root runtime user. UID/GID are ARGs so consumers can align them with a
 # host volume's ownership without editing the Dockerfile; defaults match the

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,13 @@ WORKDIR /
 # cached layer still ships 3.5.5-r0).
 ARG APK_UPGRADE_WEEK=manual
 RUN apk upgrade --no-cache
-RUN addgroup -g 1000 srvgroup && \
-    adduser -D srvuser -u 1000 -G srvgroup
+# Non-root runtime user. UID/GID are ARGs so consumers can align them with a
+# host volume's ownership without editing the Dockerfile; defaults match the
+# container-structure-test expectation (srvuser:x:1000:1000).
+ARG APP_UID=1000
+ARG APP_GID=1000
+RUN addgroup -g ${APP_GID} srvgroup && \
+    adduser -D srvuser -u ${APP_UID} -G srvgroup
 USER srvuser:srvgroup
 
 # runtime image
@@ -41,11 +46,21 @@ USER srvuser:srvgroup
 
 COPY --from=build /app/main /
 
+# Bind port. ARG sets the build-time default; ENV exposes it to the app
+# (app.Port() reads SERVER_PORT) and to the HEALTHCHECK CMD below, so a single
+# `--build-arg APP_INTERNAL_PORT=…` moves the listen port and its probe in
+# lockstep. Still overridable at runtime with `-e SERVER_PORT=…`.
+ARG APP_INTERNAL_PORT=8080
+ENV SERVER_PORT=${APP_INTERNAL_PORT}
+EXPOSE ${APP_INTERNAL_PORT}
+
 # HEALTHCHECK introspects the container itself, so the host portion is fixed
 # to 127.0.0.1 (loopback inside the namespace). Port comes from $SERVER_PORT
 # at runtime, falling back to 8080 to match .env. SERVER_HOST is also
 # overridable for non-default bind addresses (e.g., binding to a sidecar
 # proxy's loopback IP).
+# (HEALTHCHECK timing flags are parse-time literals — they cannot be ARG/ENV-
+# expanded, so they intentionally stay as literals per the param-externalization rule.)
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
   CMD wget --no-verbose --tries=1 --spider \
       "http://${SERVER_HOST:-127.0.0.1}:${SERVER_PORT:-8080}/" || exit 1

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,11 @@ NODE_VERSION        := $(shell cat .nvmrc 2>/dev/null || echo 24)
 MISE_VERSION        := 2026.5.13
 # renovate: datasource=docker depName=minlag/mermaid-cli
 MERMAID_CLI_VERSION := 11.15.0
+# Runner image `act` maps to the workflow's `runs-on: ubuntu-latest`. Pinned to
+# a DATED, immutable catthehacker tag so `make ci-run` uses a controlled image
+# that can't shift under an `act` upgrade. Renovate tracks it via the comment.
+# renovate: datasource=docker depName=catthehacker/ubuntu versioning=loose
+ACT_UBUNTU_VERSION  := act-latest-20260601
 
 # Ensure tools installed to ~/.local/bin (mise bootstrap lives here) AND mise's
 # shim dir (hadolint, trivy, act, goreleaser, golangci-lint, gosec, gitleaks,
@@ -464,6 +469,7 @@ ci-run: deps
 		act push -W .github/workflows/ci.yml \
 			--job $$job \
 			--eventpath $$EVENT \
+			-P ubuntu-latest=catthehacker/ubuntu:$(ACT_UBUNTU_VERSION) \
 			--container-architecture linux/amd64 \
 			--pull=false \
 			--artifact-server-port "$$ACT_PORT" \
@@ -589,7 +595,7 @@ deps-prune-check: deps
 	@echo "No prunable dependencies found."
 
 .PHONY: help deps deps-mise deps-image deps-check api-docs test integration-test fuzz bench bench-save bench-compare \
-	lint lint-scripts-exec vulncheck secrets sec lint-ci format format-check check-go-alignment static-check mermaid-lint release-check build run release update open-swagger \
+	lint lint-scripts-exec vulncheck secrets sec lint-ci format format-check check-go-alignment check-docs-go-version static-check mermaid-lint release-check build run release update open-swagger \
 	test-case-one test-case-two test-case-three e2e e2e-quick clean coverage coverage-check \
 	ci ci-run check trivy-fs trivy-image \
 	require-docker image-build image-run image-stop image-push image-smoke-test image-structure-test image-test image-scan \

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Layered Go microservice with a single HTTP endpoint over an in-memory algorithm 
 flowchart LR
     client["API Client<br/>(curl / Postman / browser)"]
     subgraph server["flight-path (Echo v5)"]
-        mw["Middleware stack<br/>RequestLogger · Recover · CORS · Secure<br/>Cache-Control · CORP"]
+        mw["Middleware stack<br/>RequestID · RequestLogger · Recover · BodyLimit<br/>Gzip · RateLimiter · CORS · Secure · Cache-Control · CORP"]
         routes["Routes<br/>POST /calculate<br/>GET /<br/>GET /swagger/*"]
         handlers["Handlers<br/>FlightCalculate<br/>ServerHealthCheck"]
         algo["FindItinerary()<br/>O(n) in-memory graph walk"]
@@ -211,7 +211,8 @@ Run `make help` to see all available targets.
 | `make mermaid-lint` | Validate Mermaid diagrams in markdown files |
 | `make release-check` | Validate `.goreleaser.yml` syntax and config via `goreleaser check` |
 | `make check-go-alignment` | Verify the Go version matches across `go.mod` and `.mise.toml` |
-| `make static-check` | Run code static check (check-go-alignment + format-check + lint-ci + lint + sec + vulncheck + secrets + trivy-fs + mermaid-lint + release-check) |
+| `make check-docs-go-version` | Verify the Go version referenced in docs matches `go.mod` |
+| `make static-check` | Run code static check (check-go-alignment + check-docs-go-version + format-check + lint-ci + lint + sec + vulncheck + secrets + trivy-fs + mermaid-lint + release-check) |
 
 ### Docker
 
@@ -232,7 +233,7 @@ Run `make help` to see all available targets.
 
 | Target | Description |
 |--------|-------------|
-| `make ci` | Run full CI pipeline locally (deps + static-check + test + integration-test + coverage-check + build + fuzz + deps-prune-check) |
+| `make ci` | Run full CI pipeline locally (deps + static-check + test + integration-test + coverage + coverage-check + build + fuzz + deps-prune-check) |
 | `make ci-run` | Run GitHub Actions workflow locally using [act](https://github.com/nektos/act) |
 | `make check` | Run pre-commit checklist (alias for `make ci`) |
 
@@ -261,7 +262,7 @@ GitHub Actions runs on every push to `main`, tags `v*`, and pull requests. All j
 | Job | Triggers | Steps |
 |-----|----------|-------|
 | **changes** | push, PR, tags | `dorny/paths-filter` — emits `code` output. Filter: `!(**.md|docs/**|specs/**|LICENSE|.gitignore|.claudeignore|.claude/**|benchmarks/**|**.png|**.jpg|**.gif|**.svg)` plus `CLAUDE.md` re-include. |
-| **static-check** | code changes | `make static-check` (format-check + lint-ci + lint + sec + vulncheck + secrets + trivy-fs + mermaid-lint + release-check) |
+| **static-check** | code changes | `make static-check` (check-go-alignment + check-docs-go-version + format-check + lint-ci + lint + sec + vulncheck + secrets + trivy-fs + mermaid-lint + release-check) |
 | **build** | code changes, after static-check | Build binary, upload artifact |
 | **test** | code changes, after static-check | Coverage threshold check (80%+), fuzz tests |
 | **integration-test** | code changes, after static-check | Full HTTP stack + middleware tests (`//go:build integration`) |
@@ -275,6 +276,7 @@ GitHub Actions runs on every push to `main`, tags `v*`, and pull requests. All j
 
 | Name | Type | Used by | How to obtain |
 |------|------|---------|---------------|
+| `GITHUB_TOKEN` | Secret (auto-provided) | `goreleaser`, `docker` jobs | Automatically injected by GitHub Actions — no manual setup. Used for GitHub Release creation and GHCR push/login. |
 | `CLAUDE_CONFIG_TOKEN` | Secret | `claude.yml`, `claude-ci-fix.yml` | PAT with `contents: read` for [`AndriyKalashnykov/claude-config`](https://github.com/AndriyKalashnykov/claude-config) — allows workflows to check out shared Claude configuration |
 | `ANTHROPIC_API_KEY` | Secret | `claude.yml`, `claude-ci-fix.yml` | [console.anthropic.com](https://console.anthropic.com/) API key — powers the Claude Code action |
 | `ACT` | Variable (local-only) | `dast` job guard, upload-artifact guards in `ci.yml` and `nightly-fuzz.yml` | Injected by `make ci-run` via `--var ACT=true`. Do **not** set on GitHub Actions runners — it would skip the `dast` job in production CI. |

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md) for Container, request-flow s
 | Component | Technology | Rationale |
 |-----------|------------|-----------|
 | Language | Go 1.26.4 (from `go.mod`) | Statically compiled binary, strong stdlib HTTP, goroutine concurrency |
-| Framework | Echo v5.1.1 | Lightweight router with built-in JSON binding, middleware stack, Swagger integration |
+| Framework | Echo v5.2.0 | Lightweight router with built-in JSON binding, middleware stack, Swagger integration |
 | API Docs | Swagger (swaggo/swag v2) | Auto-generated OpenAPI spec from Go annotations |
 | Testing | go test (unit, bench, fuzz), Newman/Postman (E2E) | Table-driven unit tests + black-box API tests against the built binary |
 | Linting | golangci-lint v2.12.2, hadolint, actionlint, shellcheck, mermaid-cli (via Docker) | Meta-linter + Dockerfile + workflows + shell + diagrams |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -45,7 +45,7 @@ sequenceDiagram
 
     C->>E: POST /calculate<br/>Body: [["SFO","ATL"],["ATL","EWR"]]
     E->>MW: Request passes through middleware
-    MW-->>MW: Logger → Recover → CORS → Security Headers → Cache-Control
+    MW-->>MW: RequestID → Logger → Recover → BodyLimit → Gzip → RateLimiter → CORS → Security Headers → Cache-Control
     MW->>H: Route matched → handler called
 
     H->>H: Bind JSON payload to [][]string

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -17,7 +17,7 @@ C4Container
     Person(client, "API Client", "cURL, Postman, Newman, browser")
 
     System_Boundary(api, "Flight Path API") {
-        Container(server, "flight-path server", "Go 1.26.4, Echo v5.1.1", "Single static binary. Serves POST /calculate, GET /, and GET /swagger/* (embedded Swagger UI via swaggo/echo-swagger v2.0.1). Middleware: RequestID, Logger, Recover, BodyLimit 1 MiB, Gzip, RateLimiter (100/s, burst 200), CORS (multi-origin via CORS_ORIGIN), Secure headers, Cache-Control no-store.")
+        Container(server, "flight-path server", "Go 1.26.4, Echo v5.2.0", "Single static binary. Serves POST /calculate, GET /, and GET /swagger/* (embedded Swagger UI via swaggo/echo-swagger v2.0.1). Middleware: RequestID, Logger, Recover, BodyLimit 1 MiB, Gzip, RateLimiter (100/s, burst 200), CORS (multi-origin via CORS_ORIGIN), Secure headers, Cache-Control no-store.")
     }
 
     Rel(client, server, "POST /calculate, GET /, GET /swagger/*", "HTTPS / JSON")

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/AndriyKalashnykov/flight-path
 go 1.26.4
 
 require (
-	github.com/labstack/echo/v5 v5.1.1
+	github.com/labstack/echo/v5 v5.2.0
 	github.com/swaggo/echo-swagger/v2 v2.0.1
 	github.com/swaggo/swag/v2 v2.0.0-rc5
 )

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/go-openapi/testify/v2 v2.4.0 h1:8nsPrHVCWkQ4p8h1EsRVymA2XABB4OT40gcvA
 github.com/go-openapi/testify/v2 v2.4.0/go.mod h1:HCPmvFFnheKK2BuwSA0TbbdxJ3I16pjwMkYkP4Ywn54=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/labstack/echo/v5 v5.1.1 h1:4QkvKoS8ps5ch49t8b72QS9Z581ytgxhTzxuB/CBA2I=
-github.com/labstack/echo/v5 v5.1.1/go.mod h1:SyvlSdObGjRXeQfCCXW/sybkZdOOQZBmpKF0bvALaeo=
+github.com/labstack/echo/v5 v5.2.0 h1:jc+Bmzz1D5F6DvrcV3Sz8lKsKm8MbPpHk0nv9dqyVr0=
+github.com/labstack/echo/v5 v5.2.0/go.mod h1:SyvlSdObGjRXeQfCCXW/sybkZdOOQZBmpKF0bvALaeo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=

--- a/internal/app/app_integration_test.go
+++ b/internal/app/app_integration_test.go
@@ -285,6 +285,80 @@ func TestCalculateCircularPath(t *testing.T) {
 	}
 }
 
+// TestCalculateSelfLoopRejected asserts a segment whose source equals its
+// destination is rejected with 400 + Index through the full middleware chain.
+// The documented contract states source and destination cannot be the same.
+func TestCalculateSelfLoopRejected(t *testing.T) {
+	s := newTestServer(t, nil)
+	body := bytes.NewBufferString(`[["SFO","ATL"],["EWR","EWR"]]`)
+	req := must(http.NewRequest(http.MethodPost, s.URL+"/calculate", body))
+	req.Header.Set("Content-Type", "application/json")
+	resp := do(t, req)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("self-loop: want 400, got %d", resp.StatusCode)
+	}
+	var env map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if msg, _ := env["Error"].(string); !strings.Contains(strings.ToLower(msg), "differ") {
+		t.Errorf("Error: want substring 'differ', got %q", msg)
+	}
+	if idx, ok := env["Index"].(float64); !ok || int(idx) != 1 {
+		t.Errorf("Index: want 1, got %v", env["Index"])
+	}
+}
+
+// TestCalculateEmptyAirportRejected asserts a segment containing an empty
+// airport code is rejected with 400 + Index rather than silently producing a
+// success response with an empty-string airport.
+func TestCalculateEmptyAirportRejected(t *testing.T) {
+	s := newTestServer(t, nil)
+	body := bytes.NewBufferString(`[["","EWR"]]`)
+	req := must(http.NewRequest(http.MethodPost, s.URL+"/calculate", body))
+	req.Header.Set("Content-Type", "application/json")
+	resp := do(t, req)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("empty airport: want 400, got %d", resp.StatusCode)
+	}
+	var env map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if msg, _ := env["Error"].(string); !strings.Contains(strings.ToLower(msg), "non-empty") {
+		t.Errorf("Error: want substring 'non-empty', got %q", msg)
+	}
+}
+
+// TestRateLimiterEnforced asserts the RateLimiter middleware actually rejects a
+// burst that exceeds the configured rate. The limits are lowered via the
+// RATE_LIMIT_PER_SEC / RATE_LIMIT_BURST env vars (read at app.New() time) so a
+// small in-process burst deterministically trips the 429 path — guarding
+// against a regression that silently disables the limiter (it would otherwise
+// have no assertion at any layer).
+func TestRateLimiterEnforced(t *testing.T) {
+	s := newTestServer(t, map[string]string{
+		"RATE_LIMIT_PER_SEC": "1",
+		"RATE_LIMIT_BURST":   "1",
+	})
+	const attempts = 20
+	got429 := false
+	for i := 0; i < attempts; i++ {
+		resp := do(t, must(http.NewRequest(http.MethodGet, s.URL+"/", nil)))
+		code := resp.StatusCode
+		resp.Body.Close()
+		if code == http.StatusTooManyRequests {
+			got429 = true
+			break
+		}
+	}
+	if !got429 {
+		t.Errorf("rate limiter: expected at least one 429 across %d rapid requests at rate=1/burst=1, got none", attempts)
+	}
+}
+
 func TestSwaggerUIRedirect(t *testing.T) {
 	s := newTestServer(t, nil)
 	client := &http.Client{CheckRedirect: func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse }}

--- a/internal/envfile/envfile.go
+++ b/internal/envfile/envfile.go
@@ -10,6 +10,9 @@
 //	KEY=value
 //	KEY = value            (whitespace around '=' is trimmed)
 //	KEY="quoted value"     (outer single or double quotes are stripped)
+//	export KEY=value       (a leading "export " prefix is stripped)
+//	KEY=value # comment     (an inline comment after whitespace is stripped
+//	                         from UNQUOTED values; '#' inside quotes is kept)
 //	                       (blank lines are ignored)
 //
 // Already-set variables are NOT overwritten, which matches godotenv's default
@@ -55,13 +58,17 @@ func Load(path string) error {
 			return fmt.Errorf("envfile: %s:%d: missing '='", path, lineNo)
 		}
 		key = strings.TrimSpace(key)
+		// Strip an optional "export " prefix (common in shell-sourced files).
+		if rest, found := strings.CutPrefix(key, "export "); found {
+			key = strings.TrimSpace(rest)
+		}
 		if key == "" {
 			return fmt.Errorf("envfile: %s:%d: empty key", path, lineNo)
 		}
 		if _, exists := os.LookupEnv(key); exists {
 			continue
 		}
-		val = strings.Trim(strings.TrimSpace(val), `"'`)
+		val = parseValue(val)
 		if err := os.Setenv(key, val); err != nil {
 			return fmt.Errorf("envfile: %s:%d: setenv %s: %w", path, lineNo, key, err)
 		}
@@ -70,4 +77,28 @@ func Load(path string) error {
 		return fmt.Errorf("envfile: %s: read: %w", path, err)
 	}
 	return nil
+}
+
+// parseValue normalizes a raw value: it strips surrounding whitespace, then
+// either removes outer single/double quotes (preserving any '#' inside) or, for
+// an unquoted value, drops an inline comment introduced by whitespace + '#'.
+// A bare '#' with no preceding whitespace (e.g. a literal "pa#ss") is kept.
+func parseValue(raw string) string {
+	v := strings.TrimSpace(raw)
+	if v == "" {
+		return ""
+	}
+	if v[0] == '"' || v[0] == '\'' {
+		return strings.Trim(v, `"'`)
+	}
+	if v[0] == '#' {
+		return ""
+	}
+	if i := strings.IndexAny(v, " \t"); i >= 0 {
+		// Look for a '#' that begins a comment after the first whitespace run.
+		if c := strings.Index(v[i:], "#"); c >= 0 {
+			v = v[:i+c]
+		}
+	}
+	return strings.TrimSpace(v)
 }

--- a/internal/envfile/envfile_test.go
+++ b/internal/envfile/envfile_test.go
@@ -63,6 +63,31 @@ func TestLoad(t *testing.T) {
 			content: "FP_TEST_FOO=bar",
 			want:    map[string]string{"FP_TEST_FOO": "bar"},
 		},
+		{
+			name:    "export prefix is stripped",
+			content: "export FP_TEST_FOO=bar\n",
+			want:    map[string]string{"FP_TEST_FOO": "bar"},
+		},
+		{
+			name:    "inline comment after whitespace is stripped from unquoted value",
+			content: "FP_TEST_FOO=bar  # trailing note\n",
+			want:    map[string]string{"FP_TEST_FOO": "bar"},
+		},
+		{
+			name:    "hash without preceding whitespace is kept in value",
+			content: "FP_TEST_FOO=pa#ss\n",
+			want:    map[string]string{"FP_TEST_FOO": "pa#ss"},
+		},
+		{
+			name:    "hash inside quotes is preserved",
+			content: `FP_TEST_FOO="pa #ss"` + "\n",
+			want:    map[string]string{"FP_TEST_FOO": "pa #ss"},
+		},
+		{
+			name:    "value that is entirely a comment becomes empty",
+			content: "FP_TEST_FOO= # only a comment\n",
+			want:    map[string]string{"FP_TEST_FOO": ""},
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/handlers/flight.go
+++ b/internal/handlers/flight.go
@@ -11,6 +11,10 @@ import (
 // errorKey is the JSON field name for error messages in 400/500 responses.
 const errorKey = "Error"
 
+// indexKey is the JSON field naming the offending segment's index in
+// per-segment validation errors.
+const indexKey = "Index"
+
 // FlightCalculate godoc
 // @Summary Determine the flight path of a person.
 // @Description get the flight path of a person.
@@ -46,12 +50,25 @@ func (h Handler) FlightCalculate(c *echo.Context) error {
 		if len(v) < 2 {
 			return c.JSON(http.StatusBadRequest, map[string]any{
 				errorKey: "Each flight segment must contain both source and destination",
-				"Index":  i,
+				indexKey: i,
+			})
+		}
+		src, dst := v[0], v[1]
+		if src == "" || dst == "" {
+			return c.JSON(http.StatusBadRequest, map[string]any{
+				errorKey: "Airport codes must be non-empty",
+				indexKey: i,
+			})
+		}
+		if src == dst {
+			return c.JSON(http.StatusBadRequest, map[string]any{
+				errorKey: "Source and destination airports must differ",
+				indexKey: i,
 			})
 		}
 		flights = append(flights, api.Flight{
-			Start: v[0],
-			End:   v[1],
+			Start: src,
+			End:   dst,
 		})
 	}
 

--- a/internal/handlers/flight_test.go
+++ b/internal/handlers/flight_test.go
@@ -51,6 +51,16 @@ func TestFlightCalculate(t *testing.T) {
 			wantStatus: http.StatusBadRequest,
 		},
 		{
+			name:       "segment with empty airport code returns 400",
+			body:       `[["","EWR"]]`,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "self-loop segment returns 400",
+			body:       `[["SFO","SFO"]]`,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
 			name:       "malformed JSON returns 400",
 			body:       `not json`,
 			wantStatus: http.StatusBadRequest,


### PR DESCRIPTION
Full project-health pass: `/project-review` (8 parallel agents) → `/upgrade-analysis` → `/renovate` → `/readme` → `/ship-it`. Every BLOCKING/HIGH policy check already passed; this lands the real gaps found, plus one security dependency bump.

## Code (real fixes + tests)
- **`flight.go`**: reject empty-string airport codes (`["","EWR"]` previously returned success) and self-loops (`src == dst`) at the handler layer per the documented contract; extracted `indexKey` constant.
- **`envfile.go`**: strip an `export ` prefix and unquoted inline comments (` # …`), matching godotenv; `#` inside quotes and bare `pa#ss` preserved.
- **Tests added**: rate-limiter burst (the one wired middleware with zero assertions at any layer — a regression would have shipped green), self-loop/empty-airport HTTP-layer cases, envfile export/comment cases, handler-unit empty/self-loop cases.

## Dependency (security)
- **echo/v5 v5.1.1 → v5.2.0** — fixes GHSA-vfp3-v2gw-7wfq (encoded path-separator middleware bypass in static-file serving). Drop-in; full test pyramid + govulncheck green.

## Config
- **Dockerfile**: `ARG APP_UID/APP_GID/APP_INTERNAL_PORT` (defaults preserve 1000/1000/8080 + the container-structure-test assertion) for build-time tunability.
- **Makefile**: pin `act`'s runner image to a dated `catthehacker/ubuntu` tag mapped to `ubuntu-latest` (`ACT_UBUNTU_VERSION`, Renovate-tracked via the existing customManager); add `check-docs-go-version` to `.PHONY`.

## Docs
- **README**: add `GITHUB_TOKEN` to Required Secrets table; fix `make ci` (coverage) and `static-check` (check-docs-go-version) descriptions; list all 9 middlewares in the flowchart for parity with the Container diagram; cascade Echo v5.2.0.
- **CLAUDE.md**: correct the `claude.yml` "automated PR review" claim (interactive-only); update the echo-swagger swag-v1 backlog item (upstream PR #146 closed unmerged, issue #147 still open); add `check-docs-go-version` + `ACT_UBUNTU_VERSION`; cascade Echo v5.2.0.
- **ARCHITECTURE.md**: full middleware chain in the request-flow sequence diagram; Echo v5.2.0 tech-string.

## Verification
- `make ci` (full local pipeline) PASS: static-check, test, integration-test, coverage-check (80%), build, 30s fuzz, deps-prune-check.
- `make image-test` PASS (Dockerfile ARG changes build; `srvuser:1000:1000` structure assertion holds).
- `make renovate-validate` clean; `regex` manager extracts the new `ACT_UBUNTU_VERSION` pin, 0 collisions.
- `make mermaid-lint` PASS (both diagram files render).

## Renovate / Docker hardening (no changes — already compliant)
- Renovate config fully compliant (cross-manager Go-toolchain group, govulncheck override, pinDigests guard verified by effect).
- Docker pipeline already hardened to Pattern A (Trivy fs+image, cosign-by-digest, multi-arch, weekly apk-upgrade) — no action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)