### PR TITLE
docs: sync static-check enumerations + tool list for diagrams-check

### DIFF
--- a/.claude/skills/workflows/SKILL.md
+++ b/.claude/skills/workflows/SKILL.md
@@ -84,7 +84,7 @@ Pipeline in `.github/workflows/ci.yml`, runs on push to `main`, tags `v*`, and P
 | Job | Needs | What it runs |
 |---|---|---|
 | `changes` | — | `dorny/paths-filter` — emits the `code` gate output |
-| `static-check` | changes | `make static-check` (incl. check-go-alignment, check-docs-go-version, lint, sec, vulncheck, secrets, trivy-fs, mermaid-lint, release-check) |
+| `static-check` | changes | `make static-check` (incl. check-go-alignment, check-docs-go-version, lint, sec, vulncheck, secrets, trivy-fs, mermaid-lint, diagrams-check, release-check) |
 | `build` | changes, static-check | `make build` + upload binary artifact |
 | `test` | changes, static-check | `make coverage` + `make coverage-check` (80%) + `make fuzz` |
 | `integration-test` | changes, static-check | `make integration-test` (full HTTP stack via httptest) |

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ GitHub Actions runs on every push to `main`, tags `v*`, and pull requests. All j
 | Job | Triggers | Steps |
 |-----|----------|-------|
 | **changes** | push, PR, tags | `dorny/paths-filter` — emits `code` output. Filter: `!(**.md|docs/**|specs/**|LICENSE|.gitignore|.claudeignore|.claude/**|benchmarks/**|**.png|**.jpg|**.gif|**.svg)` plus `CLAUDE.md` re-include. |
-| **static-check** | code changes | `make static-check` (check-go-alignment + check-docs-go-version + format-check + lint-ci + lint + sec + vulncheck + secrets + trivy-fs + mermaid-lint + release-check) |
+| **static-check** | code changes | `make static-check` (check-go-alignment + check-docs-go-version + format-check + lint-ci + lint + sec + vulncheck + secrets + trivy-fs + mermaid-lint + diagrams-check + release-check) |
 | **build** | code changes, after static-check | Build binary, upload artifact |
 | **test** | code changes, after static-check | Coverage threshold check (80%+), fuzz tests |
 | **integration-test** | code changes, after static-check | Full HTTP stack + middleware tests (`//go:build integration`) |

--- a/specs/BUILD.md
+++ b/specs/BUILD.md
@@ -22,6 +22,7 @@ Go and Node are provisioned by [mise](https://mise.jdx.dev/) from `.mise.toml` (
 | benchstat | Go install pinned via `BENCHSTAT_VERSION` in `Makefile` | Benchmark comparison |
 | newman | `pnpm install` in `test/` (pinned in `test/package.json`) | Postman collection runner |
 | mermaid-cli | Docker image pinned via `MERMAID_CLI_VERSION` in `Makefile` | Mermaid diagram validator |
+| PlantUML | Docker image pinned via `PLANTUML_VERSION` in `Makefile` | C4 architecture diagram renderer (`make diagrams` / `diagrams-check`) |
 
 ## Build Flags
 
@@ -52,7 +53,7 @@ api-docs → go build
 1. **api-docs** — `swag init --parseDependency -g main.go` regenerates `docs/swagger.{json,yaml,go}` from handler annotations
 2. **go build** — `go build -a -o server main.go` (static binary via `CGO_ENABLED=0`)
 
-Upstream quality/security gates (lint, sec, vulncheck, secrets, trivy-fs, mermaid-lint, release-check) live in `make static-check` and are not prerequisites of `make build` — they run in their own CI job and in `make ci`.
+Upstream quality/security gates (lint, sec, vulncheck, secrets, trivy-fs, mermaid-lint, diagrams-check, release-check) live in `make static-check` and are not prerequisites of `make build` — they run in their own CI job and in `make ci`.
 
 ## Run Locally
 

--- a/specs/CI-CD.md
+++ b/specs/CI-CD.md
@@ -20,7 +20,7 @@ Default `contents: read`. Elevated permissions are scoped per job that needs the
 
 | Job | Triggers | Depends on | Timeout | Steps |
 |---|---|---|---|---|
-| **static-check** | all | — | 15 min | `mise install`, `make static-check` (lint-ci + lint + sec + vulncheck + secrets + trivy-fs + mermaid-lint + release-check) |
+| **static-check** | all | — | 15 min | `mise install`, `make static-check` (lint-ci + lint + sec + vulncheck + secrets + trivy-fs + mermaid-lint + diagrams-check + release-check) |
 | **build** | all | static-check | 10 min | `go build`, upload `server-binary` artifact |
 | **test** | all | static-check | 15 min | `make coverage-check` (80% floor), upload coverage artifact |
 | **integration-test** | all | static-check | 10 min | `make integration-test` — full HTTP stack via `httptest` and `//go:build integration` |


### PR DESCRIPTION
Follow-up to #286 (C4 Mermaid → PlantUML). Four doc enumerations missed `diagrams-check` / PlantUML and are now synced:

- `README.md` CI/CD job table — static-check step
- `specs/CI-CD.md` — static-check pipeline row
- `specs/BUILD.md` — static gate list + tool inventory (adds PlantUML row)
- `.claude/skills/workflows/SKILL.md` — CI job table

Docs-only (paths-filter `code=false` → `changes` + `ci-pass` only). Caught by a post-merge completeness audit.