### PR TITLE
fix(makefile): guard release target against pre-existing tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -357,6 +357,8 @@ release: ci
 	}
 	@NT=$$(bash -c 'read -p "Please provide a new tag (current tag - $(CURRENTTAG)): " newtag; echo $$newtag'); \
 	echo "$$NT" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$$' || { echo "Error: Tag must match vN.N.N"; exit 1; }; \
+	if git rev-parse -q --verify "refs/tags/$$NT" >/dev/null 2>&1; then echo "ERROR: tag $$NT already exists locally. Pick a new version or delete it: git tag -d $$NT"; exit 1; fi; \
+	if git ls-remote --exit-code --tags origin "refs/tags/$$NT" >/dev/null 2>&1; then echo "ERROR: tag $$NT already exists on origin. Pick a new version."; exit 1; fi; \
 	read -p "Are you sure to create and push $$NT tag? [y/N] " ans; [ "$${ans:-N}" = y ] || exit 1; \
 	echo "$$NT" > ./pkg/api/version.txt; \
 	git add pkg/api/version.txt; \


### PR DESCRIPTION
The `release` recipe wrote the version file and ran `git commit` before `git tag`, with no check that the target tag was free. Re-running with an already-published tag would land a dangling "Cut vX release" commit while `git tag` aborted — a half-published release (Makefile Safety Check #16).

**Fix:** add a fail-before-mutation guard right after semver validation and before the confirm prompt — reject the tag if it exists locally (`git rev-parse --verify`) or on origin (`git ls-remote --tags`). No behavior change on the happy path.

Verified: guard fires before any commit/tag against an existing tag (`v0.0.3`), leaving `git status` clean; `make -n release` parses cleanly.